### PR TITLE
Provide CSV reports for Data Labs and Performance Analysts

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ The following environment variables are available:
   of colleagues at the cabinet office who will be emailed upon a successful export
 - `DATA_LABS_EMAIL_RECIPIENTS` - a comma separated list of email addresses
   of colleagues in the Data Labs team who will be emailed upon a successful export
+- `PERFORMANCE_ANALYST_EMAIL_RECIPIENTS` - a comma separated list of email addresses
+  of performance analysts who will be emailed upon a successful export
 - `THIRD_PARTY_EMAIL_RECIPIENTS` - a comma separated list of email addresses
   of third party colleagues who will be emailed upon a successful export
 - `SINCE_TIME` (optional) - defaults to "10:00", can be changed to alter the time

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ The following environment variables are available:
   files are ready
 - `CABINET_OFFICE_EMAIL_RECIPIENTS` - a comma separated list of email addresses
   of colleagues at the cabinet office who will be emailed upon a successful export
+- `DATA_LABS_EMAIL_RECIPIENTS` - a comma separated list of email addresses
+  of colleagues in the Data Labs team who will be emailed upon a successful export
 - `THIRD_PARTY_EMAIL_RECIPIENTS` - a comma separated list of email addresses
   of third party colleagues who will be emailed upon a successful export
 - `SINCE_TIME` (optional) - defaults to "10:00", can be changed to alter the time

--- a/lib/ask_export/csv_builder.rb
+++ b/lib/ask_export/csv_builder.rb
@@ -7,7 +7,8 @@ module AskExport
     end
 
     def cabinet_office
-      build_csv(:id,
+      build_csv(report.completed_responses,
+                :id,
                 :submission_time,
                 :region,
                 :name,
@@ -17,11 +18,26 @@ module AskExport
     end
 
     def data_labs
-      build_csv(:submission_time, :region, :question, :question_format)
+      build_csv(report.completed_responses,
+                :submission_time,
+                :region,
+                :question,
+                :question_format)
+    end
+
+    def performance_analyst
+      build_csv(report.responses,
+                :start_time,
+                :submission_time,
+                :status,
+                :user_agent,
+                :client_id,
+                :region)
     end
 
     def third_party
-      build_csv(:id,
+      build_csv(report.completed_responses,
+                :id,
                 :submission_time,
                 :region,
                 :question,
@@ -32,10 +48,10 @@ module AskExport
 
     attr_reader :report
 
-    def build_csv(*fields)
+    def build_csv(responses, *fields)
       CSV.generate do |csv|
         csv << fields
-        report.responses.each { |row| csv << row.slice(*fields).values }
+        responses.each { |row| csv << row.slice(*fields).values }
       end
     end
   end

--- a/lib/ask_export/csv_builder.rb
+++ b/lib/ask_export/csv_builder.rb
@@ -16,6 +16,10 @@ module AskExport
                 :question_format)
     end
 
+    def data_labs
+      build_csv(:submission_time, :region, :question, :question_format)
+    end
+
     def third_party
       build_csv(:id,
                 :submission_time,

--- a/lib/ask_export/file_export.rb
+++ b/lib/ask_export/file_export.rb
@@ -13,12 +13,17 @@ module AskExport
     def call
       csv_builder = CsvBuilder.new(report)
 
-      File.write(cabinet_office_path, csv_builder.cabinet_office, mode: "w")
-      File.write(data_labs_path, csv_builder.data_labs, mode: "w")
-      File.write(third_party_path, csv_builder.third_party, mode: "w")
+      files = {
+        output_path("cabinet-office") => csv_builder.cabinet_office,
+        output_path("data-labs") => csv_builder.data_labs,
+        output_path("performance-analyst") => csv_builder.performance_analyst,
+        output_path("third-party") => csv_builder.third_party,
+      }
 
-      puts "CSV files have been output to #{relative_to_cwd(cabinet_office_path)}, " \
-        "#{relative_to_cwd(data_labs_path)} and #{relative_to_cwd(third_party_path)}"
+      files.each { |path, data| File.write(path, data, mode: "w") }
+      relative_paths = files.keys.map { |path| relative_to_cwd(path) }
+
+      puts "CSV files have been output to: #{relative_paths.join(', ')}"
     end
 
     private_class_method :new
@@ -27,16 +32,8 @@ module AskExport
 
     attr_reader :report
 
-    def cabinet_office_path
-      "#{output_directory}/#{report.filename_prefix}-cabinet-office.csv"
-    end
-
-    def data_labs_path
-      "#{output_directory}/#{report.filename_prefix}-data-labs.csv"
-    end
-
-    def third_party_path
-      "#{output_directory}/#{report.filename_prefix}-third-party.csv"
+    def output_path(recipient)
+      "#{output_directory}/#{report.filename_prefix}-#{recipient}.csv"
     end
 
     def output_directory

--- a/lib/ask_export/file_export.rb
+++ b/lib/ask_export/file_export.rb
@@ -14,10 +14,11 @@ module AskExport
       csv_builder = CsvBuilder.new(report)
 
       File.write(cabinet_office_path, csv_builder.cabinet_office, mode: "w")
+      File.write(data_labs_path, csv_builder.data_labs, mode: "w")
       File.write(third_party_path, csv_builder.third_party, mode: "w")
 
-      puts "CSV files have been output to #{relative_to_cwd(cabinet_office_path)} " \
-        "and #{relative_to_cwd(third_party_path)}"
+      puts "CSV files have been output to #{relative_to_cwd(cabinet_office_path)}, " \
+        "#{relative_to_cwd(data_labs_path)} and #{relative_to_cwd(third_party_path)}"
     end
 
     private_class_method :new
@@ -28,6 +29,10 @@ module AskExport
 
     def cabinet_office_path
       "#{output_directory}/#{report.filename_prefix}-cabinet-office.csv"
+    end
+
+    def data_labs_path
+      "#{output_directory}/#{report.filename_prefix}-data-labs.csv"
     end
 
     def third_party_path

--- a/lib/ask_export/partner_notifier.rb
+++ b/lib/ask_export/partner_notifier.rb
@@ -4,6 +4,7 @@ module AskExport
   class PartnerNotifier
     CABINET_OFFICE_TEMPLATE_ID = "4f81afc5-c018-4305-ad1e-b722189d4a10".freeze
     DATA_LABS_TEMPLATE_ID = "53f2afe6-e9cc-455f-847b-c2f02ba8d485".freeze
+    PERFORMANCE_ANALYST_TEMPLATE_ID = "3b4194c3-4e4a-4ebc-8cc5-c81c3613fb30".freeze
     THIRD_PARTY_TEMPLATE_ID = "959ac4b4-b640-459e-a037-981a3049d55b".freeze
 
     def self.call(*args)
@@ -16,9 +17,14 @@ module AskExport
     end
 
     def call
-      send_cabinet_office_emails
-      send_data_labs_emails
-      send_third_party_emails
+      send_emails(ENV.fetch("CABINET_OFFICE_EMAIL_RECIPIENTS"),
+                  CABINET_OFFICE_TEMPLATE_ID)
+      send_emails(ENV.fetch("DATA_LABS_EMAIL_RECIPIENTS"),
+                  DATA_LABS_TEMPLATE_ID)
+      send_emails(ENV.fetch("PERFORMANCE_ANALYST_EMAIL_RECIPIENTS"),
+                  PERFORMANCE_ANALYST_TEMPLATE_ID)
+      send_emails(ENV.fetch("THIRD_PARTY_EMAIL_RECIPIENTS"),
+                  THIRD_PARTY_TEMPLATE_ID)
     end
 
     private_class_method :new
@@ -27,26 +33,10 @@ module AskExport
 
     attr_reader :client, :report
 
-    def send_cabinet_office_emails
-      ENV.fetch("CABINET_OFFICE_EMAIL_RECIPIENTS").split(",").each do |address|
+    def send_emails(addresses, template_id)
+      addresses.split(",").each do |address|
         client.send_email(email_address: address.strip,
-                          template_id: CABINET_OFFICE_TEMPLATE_ID,
-                          personalisation: personalisation)
-      end
-    end
-
-    def send_data_labs_emails
-      ENV.fetch("DATA_LABS_EMAIL_RECIPIENTS").split(",").each do |address|
-        client.send_email(email_address: address.strip,
-                          template_id: DATA_LABS_TEMPLATE_ID,
-                          personalisation: personalisation)
-      end
-    end
-
-    def send_third_party_emails
-      ENV.fetch("THIRD_PARTY_EMAIL_RECIPIENTS").split(",").each do |address|
-        client.send_email(email_address: address.strip,
-                          template_id: THIRD_PARTY_TEMPLATE_ID,
+                          template_id: template_id,
                           personalisation: personalisation)
       end
     end
@@ -56,7 +46,8 @@ module AskExport
       {
         since_time: report.since_time.strftime(time_formatting),
         until_time: report.until_time.strftime(time_formatting),
-        responses_count: report.responses.count,
+        completed_responses_count: report.completed_responses.count,
+        all_responses_count: report.responses.count,
       }
     end
   end

--- a/lib/ask_export/partner_notifier.rb
+++ b/lib/ask_export/partner_notifier.rb
@@ -3,6 +3,7 @@ require "notifications/client"
 module AskExport
   class PartnerNotifier
     CABINET_OFFICE_TEMPLATE_ID = "4f81afc5-c018-4305-ad1e-b722189d4a10".freeze
+    DATA_LABS_TEMPLATE_ID = "53f2afe6-e9cc-455f-847b-c2f02ba8d485".freeze
     THIRD_PARTY_TEMPLATE_ID = "959ac4b4-b640-459e-a037-981a3049d55b".freeze
 
     def self.call(*args)
@@ -16,6 +17,7 @@ module AskExport
 
     def call
       send_cabinet_office_emails
+      send_data_labs_emails
       send_third_party_emails
     end
 
@@ -29,6 +31,14 @@ module AskExport
       ENV.fetch("CABINET_OFFICE_EMAIL_RECIPIENTS").split(",").each do |address|
         client.send_email(email_address: address.strip,
                           template_id: CABINET_OFFICE_TEMPLATE_ID,
+                          personalisation: personalisation)
+      end
+    end
+
+    def send_data_labs_emails
+      ENV.fetch("DATA_LABS_EMAIL_RECIPIENTS").split(",").each do |address|
+        client.send_email(email_address: address.strip,
+                          template_id: DATA_LABS_TEMPLATE_ID,
                           personalisation: personalisation)
       end
     end

--- a/lib/ask_export/report.rb
+++ b/lib/ask_export/report.rb
@@ -14,6 +14,10 @@ module AskExport
       @responses ||= SurveyResponseFetcher.call(since_time, until_time)
     end
 
+    def completed_responses
+      responses.select { |r| r[:status] == "completed" }
+    end
+
     def filename_prefix
       time_format = "%Y-%m-%d-%H%M"
       "#{since_time.strftime(time_format)}-to-#{until_time.strftime(time_format)}"

--- a/lib/ask_export/s3_export.rb
+++ b/lib/ask_export/s3_export.rb
@@ -14,6 +14,7 @@ module AskExport
       csv_builder = CsvBuilder.new(report)
 
       upload_to_s3("cabinet-office/#{report.filename_prefix}.csv", csv_builder.cabinet_office)
+      upload_to_s3("data-labs/#{report.filename_prefix}.csv", csv_builder.data_labs)
       upload_to_s3("third-party/#{report.filename_prefix}.csv", csv_builder.third_party)
 
       puts "Files uploaded to S3"

--- a/lib/ask_export/s3_export.rb
+++ b/lib/ask_export/s3_export.rb
@@ -13,9 +13,12 @@ module AskExport
     def call
       csv_builder = CsvBuilder.new(report)
 
-      upload_to_s3("cabinet-office/#{report.filename_prefix}.csv", csv_builder.cabinet_office)
-      upload_to_s3("data-labs/#{report.filename_prefix}.csv", csv_builder.data_labs)
-      upload_to_s3("third-party/#{report.filename_prefix}.csv", csv_builder.third_party)
+      {
+        output_key("cabinet-office") => csv_builder.cabinet_office,
+        output_key("data-labs") => csv_builder.data_labs,
+        output_key("performance-analyst") => csv_builder.performance_analyst,
+        output_key("third-party") => csv_builder.third_party,
+      }.each { |key, data| upload_to_s3(key, data) }
 
       puts "Files uploaded to S3"
 
@@ -29,6 +32,10 @@ module AskExport
   private
 
     attr_reader :report
+
+    def output_key(recipient)
+      "#{recipient}/#{report.filename_prefix}.csv"
+    end
 
     def upload_to_s3(key, data)
       client = Aws::S3::Resource.new.client

--- a/lib/ask_export/survey_response_fetcher/response_presenter.rb
+++ b/lib/ask_export/survey_response_fetcher/response_presenter.rb
@@ -1,0 +1,63 @@
+module AskExport
+  class SurveyResponseFetcher::ResponsePresenter
+    # Consumers of these exports are already accustumed to a particular
+    # time formatting, this is retained here so outputs remain consistent
+    SMART_SURVEY_TIME_FORMATTING = "%d/%m/%Y %H:%M:%S".freeze
+
+    def self.call(*args)
+      new(*args).call
+    end
+
+    def initialize(response)
+      @response = response
+    end
+
+    def call
+      {
+        id: response[:id],
+        client_id: client_id,
+        user_agent: response[:user_agent],
+        status: response[:status],
+        start_time: format_time(response[:date_started]),
+        submission_time: format_time(response[:date_ended]),
+        region: fetch_choice_answer(:region_field_id),
+        question: fetch_value_answer(:question_field_id),
+        question_format: fetch_choice_answer(:question_format_field_id),
+        name: fetch_value_answer(:name_field_id),
+        email: fetch_value_answer(:email_field_id),
+        phone: fetch_value_answer(:phone_field_id),
+      }
+    end
+
+    private_class_method :new
+
+  private
+
+    attr_reader :response
+
+    def client_id
+      return unless response[:variables]
+
+      response[:variables].find { |v| v[:label] == "clientID" }
+                          .then { |v| v.to_h[:value] }
+    end
+
+    def format_time(time)
+      Time.zone.iso8601(time).strftime(SMART_SURVEY_TIME_FORMATTING)
+    end
+
+    def fetch_value_answer(field_id)
+      fetch_answer(field_id).to_h[:value]
+    end
+
+    def fetch_choice_answer(field_id)
+      fetch_answer(field_id).to_h[:choice_title]
+    end
+
+    def fetch_answer(field_id)
+      response[:pages].flat_map { |page| page[:questions] }
+                      .find { |question| question[:id] == AskExport.config(field_id) }
+                      .then { |item| item.to_h[:answers]&.first }
+    end
+  end
+end

--- a/spec/ask_export/csv_builder_spec.rb
+++ b/spec/ask_export/csv_builder_spec.rb
@@ -2,70 +2,47 @@ RSpec.describe AskExport::CsvBuilder do
   let(:responses) do
     [
       presented_survey_response(id: 1, region: "Scotland"),
-      presented_survey_response(id: 2, region: "Yorkshire and the Humber"),
+      presented_survey_response(id: 2, status: "partial"),
+      presented_survey_response(id: 3, status: "disqualified", client_id: 100),
     ]
   end
+  let(:builder) { described_class.new(stubbed_report(responses: responses)) }
 
   describe "#cabinet_office" do
-    context "when there are no responses" do
-      it "returns a csv string of the headers" do
-        builder = described_class.new(stubbed_report(responses: []))
-        expect(builder.cabinet_office)
-          .to eq("id,submission_time,region,name,email,phone,question_format\n")
-      end
-    end
-
-    context "when there are responses" do
-      it "returns a csv of cabinet office data" do
-        builder = described_class.new(stubbed_report(responses: responses))
-        expect(builder.cabinet_office).to eq(
-          "id,submission_time,region,name,email,phone,question_format\n" \
-          "1,01/05/2020 09:00:00,Scotland,Jane Doe,jane@example.com,+447123456789,\"In writing, to be read out at the press conference\"\n" \
-          "2,01/05/2020 09:00:00,Yorkshire and the Humber,Jane Doe,jane@example.com,+447123456789,\"In writing, to be read out at the press conference\"\n",
-        )
-      end
+    it "returns a csv of completed records formatted for cabinet office" do
+      expect(builder.cabinet_office).to eq(
+        "id,submission_time,region,name,email,phone,question_format\n" \
+        "1,01/05/2020 09:00:00,Scotland,Jane Doe,jane@example.com,+447123456789,\"In writing, to be read out at the press conference\"\n",
+      )
     end
   end
 
   describe "#data_labs" do
-    context "when there are no responses" do
-      it "returns a csv string of the headers" do
-        builder = described_class.new(stubbed_report(responses: []))
-        expect(builder.data_labs)
-          .to eq("submission_time,region,question,question_format\n")
-      end
+    it "returns a csv of completed records formatted for data labs" do
+      expect(builder.data_labs).to eq(
+        "submission_time,region,question,question_format\n" \
+        "01/05/2020 09:00:00,Scotland,A question?,\"In writing, to be read out at the press conference\"\n",
+      )
     end
+  end
 
-    context "when there are responses" do
-      it "returns a csv of data labs data" do
-        builder = described_class.new(stubbed_report(responses: responses))
-        expect(builder.data_labs).to eq(
-          "submission_time,region,question,question_format\n" \
-          "01/05/2020 09:00:00,Scotland,A question?,\"In writing, to be read out at the press conference\"\n" \
-          "01/05/2020 09:00:00,Yorkshire and the Humber,A question?,\"In writing, to be read out at the press conference\"\n",
-        )
-      end
+  describe "#performance_analyst" do
+    it "returns a csv of all records formatted for a performance analyst" do
+      expect(builder.performance_analyst).to eq(
+        "start_time,submission_time,status,user_agent,client_id,region\n" \
+        "01/05/2020 08:55:00,01/05/2020 09:00:00,completed,NCSA Mosaic/3.0 (Windows 95),,Scotland\n" \
+        "01/05/2020 08:55:00,01/05/2020 09:00:00,partial,NCSA Mosaic/3.0 (Windows 95),,\n" \
+        "01/05/2020 08:55:00,01/05/2020 09:00:00,disqualified,NCSA Mosaic/3.0 (Windows 95),100,\n",
+      )
     end
   end
 
   describe "#third_party" do
-    context "when there are no responses" do
-      it "returns a csv string of the headers" do
-        builder = described_class.new(stubbed_report(responses: []))
-        expect(builder.third_party)
-          .to eq("id,submission_time,region,question,question_format\n")
-      end
-    end
-
-    context "when there are responses" do
-      it "returns a csv of cabinet office data" do
-        builder = described_class.new(stubbed_report(responses: responses))
-        expect(builder.third_party).to eq(
-          "id,submission_time,region,question,question_format\n" \
-          "1,01/05/2020 09:00:00,Scotland,A question?,\"In writing, to be read out at the press conference\"\n" \
-          "2,01/05/2020 09:00:00,Yorkshire and the Humber,A question?,\"In writing, to be read out at the press conference\"\n",
-        )
-      end
+    it "returns a csv of completed records formatted for a third party" do
+      expect(builder.third_party).to eq(
+        "id,submission_time,region,question,question_format\n" \
+        "1,01/05/2020 09:00:00,Scotland,A question?,\"In writing, to be read out at the press conference\"\n",
+      )
     end
   end
 end

--- a/spec/ask_export/csv_builder_spec.rb
+++ b/spec/ask_export/csv_builder_spec.rb
@@ -27,6 +27,27 @@ RSpec.describe AskExport::CsvBuilder do
     end
   end
 
+  describe "#data_labs" do
+    context "when there are no responses" do
+      it "returns a csv string of the headers" do
+        builder = described_class.new(stubbed_report(responses: []))
+        expect(builder.data_labs)
+          .to eq("submission_time,region,question,question_format\n")
+      end
+    end
+
+    context "when there are responses" do
+      it "returns a csv of data labs data" do
+        builder = described_class.new(stubbed_report(responses: responses))
+        expect(builder.data_labs).to eq(
+          "submission_time,region,question,question_format\n" \
+          "01/05/2020 09:00:00,Scotland,A question?,\"In writing, to be read out at the press conference\"\n" \
+          "01/05/2020 09:00:00,Yorkshire and the Humber,A question?,\"In writing, to be read out at the press conference\"\n",
+        )
+      end
+    end
+  end
+
   describe "#third_party" do
     context "when there are no responses" do
       it "returns a csv string of the headers" do

--- a/spec/ask_export/file_export_spec.rb
+++ b/spec/ask_export/file_export_spec.rb
@@ -15,20 +15,23 @@ RSpec.describe AskExport::FileExport do
   it "writes files for each partner named with current date" do
     csv_builder = instance_double(AskExport::CsvBuilder,
                                   cabinet_office: "cabinet-office-data",
+                                  data_labs: "data-labs-data",
                                   third_party: "third-party-data")
     allow(AskExport::CsvBuilder).to receive(:new).and_return(csv_builder)
 
     described_class.call
 
-    expect(File)
-      .to have_received(:write)
-      .with(File.expand_path("../../output/2020-04-30-1000-to-2020-05-01-1000-cabinet-office.csv", __dir__),
-            csv_builder.cabinet_office,
-            mode: "w")
-    expect(File)
-      .to have_received(:write)
-      .with(File.expand_path("../../output/2020-04-30-1000-to-2020-05-01-1000-third-party.csv", __dir__),
-            csv_builder.third_party,
-            mode: "w")
+    {
+      "cabinet-office" => csv_builder.cabinet_office,
+      "data-labs" => csv_builder.data_labs,
+      "third-party" => csv_builder.third_party,
+    }.each do |filename_suffix, data|
+      expected_file = "../../output/2020-04-30-1000-to-2020-05-01-1000-#{filename_suffix}.csv"
+      expect(File)
+        .to have_received(:write)
+        .with(File.expand_path(expected_file, __dir__),
+              data,
+              mode: "w")
+    end
   end
 end

--- a/spec/ask_export/file_export_spec.rb
+++ b/spec/ask_export/file_export_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe AskExport::FileExport do
     csv_builder = instance_double(AskExport::CsvBuilder,
                                   cabinet_office: "cabinet-office-data",
                                   data_labs: "data-labs-data",
+                                  performance_analyst: "performance-analyst-data",
                                   third_party: "third-party-data")
     allow(AskExport::CsvBuilder).to receive(:new).and_return(csv_builder)
 
@@ -24,6 +25,7 @@ RSpec.describe AskExport::FileExport do
     {
       "cabinet-office" => csv_builder.cabinet_office,
       "data-labs" => csv_builder.data_labs,
+      "performance-analyst" => csv_builder.performance_analyst,
       "third-party" => csv_builder.third_party,
     }.each do |filename_suffix, data|
       expected_file = "../../output/2020-04-30-1000-to-2020-05-01-1000-#{filename_suffix}.csv"

--- a/spec/ask_export/partner_notifier_spec.rb
+++ b/spec/ask_export/partner_notifier_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe AskExport::PartnerNotifier do
         NOTIFY_API_KEY: "secret",
         CABINET_OFFICE_EMAIL_RECIPIENTS: cabinet_office_emails,
         DATA_LABS_EMAIL_RECIPIENTS: data_labs_emails,
+        PERFORMANCE_ANALYST_EMAIL_RECIPIENTS: performance_analyst_emails,
         THIRD_PARTY_EMAIL_RECIPIENTS: third_party_emails,
       ) { example.run }
     end
@@ -25,24 +26,21 @@ RSpec.describe AskExport::PartnerNotifier do
       "person1@cabinet-office.example.com, person2@cabinet-office.example.com"
     end
 
-    let(:data_labs_emails) do
-      "person1@data-labs.example.com, person2@data-labs.example.com"
-    end
-
-    let(:third_party_emails) do
-      "person1@third-party.example.com, person2@third-party.example.com"
-    end
+    let(:data_labs_emails) { "person1@data-labs.example.com" }
+    let(:performance_analyst_emails) { "person1@performance-analyst.example.com" }
+    let(:third_party_emails) { "person1@third-party.example.com" }
 
     let(:report) do
       stubbed_report(responses: [presented_survey_response,
-                                 presented_survey_response])
+                                 presented_survey_response(status: "disqualified")])
     end
 
     let(:personalisation) do
       {
         since_time: "10:00am on 30 April 2020",
         until_time: "10:00am on 1 May 2020",
-        responses_count: 2,
+        all_responses_count: 2,
+        completed_responses_count: 1,
       }
     end
 
@@ -67,10 +65,14 @@ RSpec.describe AskExport::PartnerNotifier do
         .with(email_address: "person1@data-labs.example.com",
               template_id: described_class::DATA_LABS_TEMPLATE_ID,
               personalisation: personalisation)
+    end
+
+    it "sends emails to performance analyst recipients" do
+      described_class.call(report)
       expect(notify_client)
         .to have_received(:send_email)
-        .with(email_address: "person2@data-labs.example.com",
-              template_id: described_class::DATA_LABS_TEMPLATE_ID,
+        .with(email_address: "person1@performance-analyst.example.com",
+              template_id: described_class::PERFORMANCE_ANALYST_TEMPLATE_ID,
               personalisation: personalisation)
     end
 
@@ -79,11 +81,6 @@ RSpec.describe AskExport::PartnerNotifier do
       expect(notify_client)
         .to have_received(:send_email)
         .with(email_address: "person1@third-party.example.com",
-              template_id: described_class::THIRD_PARTY_TEMPLATE_ID,
-              personalisation: personalisation)
-      expect(notify_client)
-        .to have_received(:send_email)
-        .with(email_address: "person2@third-party.example.com",
               template_id: described_class::THIRD_PARTY_TEMPLATE_ID,
               personalisation: personalisation)
     end

--- a/spec/ask_export/partner_notifier_spec.rb
+++ b/spec/ask_export/partner_notifier_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe AskExport::PartnerNotifier do
       ClimateControl.modify(
         NOTIFY_API_KEY: "secret",
         CABINET_OFFICE_EMAIL_RECIPIENTS: cabinet_office_emails,
+        DATA_LABS_EMAIL_RECIPIENTS: data_labs_emails,
         THIRD_PARTY_EMAIL_RECIPIENTS: third_party_emails,
       ) { example.run }
     end
@@ -22,6 +23,10 @@ RSpec.describe AskExport::PartnerNotifier do
 
     let(:cabinet_office_emails) do
       "person1@cabinet-office.example.com, person2@cabinet-office.example.com"
+    end
+
+    let(:data_labs_emails) do
+      "person1@data-labs.example.com, person2@data-labs.example.com"
     end
 
     let(:third_party_emails) do
@@ -52,6 +57,20 @@ RSpec.describe AskExport::PartnerNotifier do
         .to have_received(:send_email)
         .with(email_address: "person2@cabinet-office.example.com",
               template_id: described_class::CABINET_OFFICE_TEMPLATE_ID,
+              personalisation: personalisation)
+    end
+
+    it "sends emails to data labs recipients" do
+      described_class.call(report)
+      expect(notify_client)
+        .to have_received(:send_email)
+        .with(email_address: "person1@data-labs.example.com",
+              template_id: described_class::DATA_LABS_TEMPLATE_ID,
+              personalisation: personalisation)
+      expect(notify_client)
+        .to have_received(:send_email)
+        .with(email_address: "person2@data-labs.example.com",
+              template_id: described_class::DATA_LABS_TEMPLATE_ID,
               personalisation: personalisation)
     end
 

--- a/spec/ask_export/report_spec.rb
+++ b/spec/ask_export/report_spec.rb
@@ -55,6 +55,20 @@ RSpec.describe AskExport::Report do
     end
   end
 
+  describe "#completed_responses" do
+    it "returns only completed survey responses" do
+      completed_response = presented_survey_response(status: "completed")
+      partial_response = presented_survey_response(status: "partial")
+      disqualified_response = presented_survey_response(status: "disqualified")
+
+      allow(AskExport::SurveyResponseFetcher)
+        .to receive(:call)
+        .and_return([completed_response, partial_response, disqualified_response])
+
+      expect(described_class.new.completed_responses).to eq([completed_response])
+    end
+  end
+
   describe "#filename_prefix" do
     it "returns a the time range as a prefix" do
       expect(described_class.new.filename_prefix)

--- a/spec/ask_export/s3_export_spec.rb
+++ b/spec/ask_export/s3_export_spec.rb
@@ -23,30 +23,27 @@ RSpec.describe AskExport::S3Export do
   end
 
   describe ".call" do
-    it "uploads cabinet office, data labs and third party CSVs to S3" do
+    it "uploads cabinet office, data labs, performance_analyst and third party CSVs to S3" do
       csv_builder = instance_double(AskExport::CsvBuilder,
                                     cabinet_office: "cabinet-office-data",
                                     data_labs: "data-labs-data",
+                                    performance_analyst: "performance-analyst-data",
                                     third_party: "third-party-data")
 
       expect(AskExport::CsvBuilder).to receive(:new).and_return(csv_builder)
-      expect(s3_resource_stub.client)
-        .to receive(:put_object)
-        .with(bucket: s3_bucket,
-              key: "#{s3_path_prefix}cabinet-office/2020-04-30-1000-to-2020-05-01-1000.csv",
-              body: "cabinet-office-data")
 
-      expect(s3_resource_stub.client)
-        .to receive(:put_object)
-        .with(bucket: s3_bucket,
-              key: "#{s3_path_prefix}data-labs/2020-04-30-1000-to-2020-05-01-1000.csv",
-              body: "data-labs-data")
-
-      expect(s3_resource_stub.client)
-        .to receive(:put_object)
-        .with(bucket: s3_bucket,
-              key: "#{s3_path_prefix}third-party/2020-04-30-1000-to-2020-05-01-1000.csv",
-              body: "third-party-data")
+      {
+        "cabinet-office" => csv_builder.cabinet_office,
+        "data-labs" => csv_builder.data_labs,
+        "performance-analyst" => csv_builder.performance_analyst,
+        "third-party" => csv_builder.third_party,
+      }.each do |recipient, data|
+        expect(s3_resource_stub.client)
+          .to receive(:put_object)
+          .with(bucket: s3_bucket,
+                key: "#{s3_path_prefix + recipient}/2020-04-30-1000-to-2020-05-01-1000.csv",
+                body: data)
+      end
       described_class.call
     end
 

--- a/spec/ask_export/s3_export_spec.rb
+++ b/spec/ask_export/s3_export_spec.rb
@@ -23,9 +23,10 @@ RSpec.describe AskExport::S3Export do
   end
 
   describe ".call" do
-    it "uploads cabinet office and third party CSVs to S3" do
+    it "uploads cabinet office, data labs and third party CSVs to S3" do
       csv_builder = instance_double(AskExport::CsvBuilder,
                                     cabinet_office: "cabinet-office-data",
+                                    data_labs: "data-labs-data",
                                     third_party: "third-party-data")
 
       expect(AskExport::CsvBuilder).to receive(:new).and_return(csv_builder)
@@ -34,6 +35,12 @@ RSpec.describe AskExport::S3Export do
         .with(bucket: s3_bucket,
               key: "#{s3_path_prefix}cabinet-office/2020-04-30-1000-to-2020-05-01-1000.csv",
               body: "cabinet-office-data")
+
+      expect(s3_resource_stub.client)
+        .to receive(:put_object)
+        .with(bucket: s3_bucket,
+              key: "#{s3_path_prefix}data-labs/2020-04-30-1000-to-2020-05-01-1000.csv",
+              body: "data-labs-data")
 
       expect(s3_resource_stub.client)
         .to receive(:put_object)

--- a/spec/ask_export/survey_response_fetcher/response_presenter_spec.rb
+++ b/spec/ask_export/survey_response_fetcher/response_presenter_spec.rb
@@ -1,0 +1,44 @@
+RSpec.describe AskExport::SurveyResponseFetcher::ResponsePresenter do
+  describe ".call" do
+    it "presents a smart survey response" do
+      presented_response = presented_survey_response
+      options = presented_response.merge(
+        start_time: Time.zone.parse(presented_response[:start_time]),
+        submission_time: Time.zone.parse(presented_response[:submission_time]),
+      )
+      expect(described_class.call(smart_survey_row(options)))
+        .to eq(presented_response)
+    end
+
+    it "can present a draft smart survey response" do
+      options = { question: "Draft question?", environment: :draft }
+      expect(described_class.call(smart_survey_row(options)))
+        .to match(hash_including(question: "Draft question?"))
+    end
+
+    it "formats timestamps in the Smart Survey UK format" do
+      options = { start_time: Time.zone.parse("2020-05-01 10:45"),
+                  submission_time: Time.zone.parse("2020-05-01 11:00") }
+      expect(described_class.call(smart_survey_row(options)))
+        .to match(hash_including(start_time: "01/05/2020 10:45:00",
+                                 submission_time: "01/05/2020 11:00:00"))
+    end
+
+    it "copes on a partial response" do
+      expect(described_class.call(smart_survey_row(status: "partial")))
+        .to match(hash_including(status: "partial",
+                                 question: nil))
+    end
+
+    it "copes on a disqualified response" do
+      expect(described_class.call(smart_survey_row(status: "disqualified")))
+        .to match(hash_including(status: "disqualified",
+                                 question: nil))
+    end
+
+    it "can include a client_id" do
+      expect(described_class.call(smart_survey_row(client_id: "947770117.1576778690")))
+        .to match(hash_including(client_id: "947770117.1576778690"))
+    end
+  end
+end

--- a/spec/ask_export/survey_response_fetcher_spec.rb
+++ b/spec/ask_export/survey_response_fetcher_spec.rb
@@ -31,17 +31,16 @@ RSpec.describe AskExport::SurveyResponseFetcher do
         expect(request).to have_been_made
       end
 
-      it "returns a hash of a presented response from Smart Survey" do
+      it "delegates to ResponsePresenter to serialize the response from Smart Survey" do
+        record = smart_survey_row
+        stub_smart_survey_api(body: [record])
         presented_response = presented_survey_response
-        survey_options = presented_response.merge(submission_time: "2020-05-01T09:00:00+01:00")
-        stub_smart_survey_api(body: [smart_survey_row(survey_options)])
+        expect(described_class::ResponsePresenter).to receive(:call)
+                                                  .with(record)
+                                                  .and_return(presented_response)
+
         expect(described_class.call(since_time, until_time))
           .to eql([presented_response])
-      end
-
-      it "strips responses from Smart Survey which don't have a status of completed" do
-        stub_smart_survey_api(body: [smart_survey_row(status: "disqualified")])
-        expect(described_class.call(since_time, until_time)).to eql([])
       end
 
       it "requests multiple pages when there are more results than the page size" do

--- a/spec/integration/file_export_spec.rb
+++ b/spec/integration/file_export_spec.rb
@@ -16,9 +16,9 @@ RSpec.describe "File export" do
       end
 
       expect(smart_survey_request).to have_been_made
-      expect(File).to exist(File.join(tmpdir, "2020-05-06-2000-to-2020-05-07-1100-cabinet-office.csv"))
-      expect(File).to exist(File.join(tmpdir, "2020-05-06-2000-to-2020-05-07-1100-data-labs.csv"))
-      expect(File).to exist(File.join(tmpdir, "2020-05-06-2000-to-2020-05-07-1100-third-party.csv"))
+      %w[cabinet-office data-labs performance-analyst third-party].each do |recipient|
+        expect(File).to exist(File.join(tmpdir, "2020-05-06-2000-to-2020-05-07-1100-#{recipient}.csv"))
+      end
     end
   end
 end

--- a/spec/integration/file_export_spec.rb
+++ b/spec/integration/file_export_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe "File export" do
 
       expect(smart_survey_request).to have_been_made
       expect(File).to exist(File.join(tmpdir, "2020-05-06-2000-to-2020-05-07-1100-cabinet-office.csv"))
+      expect(File).to exist(File.join(tmpdir, "2020-05-06-2000-to-2020-05-07-1100-data-labs.csv"))
       expect(File).to exist(File.join(tmpdir, "2020-05-06-2000-to-2020-05-07-1100-third-party.csv"))
     end
   end

--- a/spec/integration/s3_export_spec.rb
+++ b/spec/integration/s3_export_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe "S3 export" do
       NOTIFY_API_KEY: "#{SecureRandom.uuid}-#{SecureRandom.uuid}",
       CABINET_OFFICE_EMAIL_RECIPIENTS: "test@example.com",
       DATA_LABS_EMAIL_RECIPIENTS: "test@example.com",
+      PERFORMANCE_ANALYST_EMAIL_RECIPIENTS: "test@example.com",
       THIRD_PARTY_EMAIL_RECIPIENTS: "test@example.com",
       SINCE_TIME: "2020-05-06 20:00",
       UNTIL_TIME: "2020-05-07 11:00",
@@ -33,7 +34,7 @@ RSpec.describe "S3 export" do
   it "fetches surveys and uploads them to s3" do
     Rake::Task["s3_export"].invoke
     expect(smart_survey_request).to have_been_made
-    expect(s3_request).to have_been_made.times(3)
-    expect(notify_request).to have_been_made.times(3)
+    expect(s3_request).to have_been_made.times(4)
+    expect(notify_request).to have_been_made.times(4)
   end
 end

--- a/spec/integration/s3_export_spec.rb
+++ b/spec/integration/s3_export_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe "S3 export" do
       S3_BUCKET: "bucket",
       NOTIFY_API_KEY: "#{SecureRandom.uuid}-#{SecureRandom.uuid}",
       CABINET_OFFICE_EMAIL_RECIPIENTS: "test@example.com",
+      DATA_LABS_EMAIL_RECIPIENTS: "test@example.com",
       THIRD_PARTY_EMAIL_RECIPIENTS: "test@example.com",
       SINCE_TIME: "2020-05-06 20:00",
       UNTIL_TIME: "2020-05-07 11:00",
@@ -32,7 +33,7 @@ RSpec.describe "S3 export" do
   it "fetches surveys and uploads them to s3" do
     Rake::Task["s3_export"].invoke
     expect(smart_survey_request).to have_been_made
-    expect(s3_request).to have_been_made.twice
-    expect(notify_request).to have_been_made.twice
+    expect(s3_request).to have_been_made.times(3)
+    expect(notify_request).to have_been_made.times(3)
   end
 end

--- a/spec/support/helpers/ask_export_helper.rb
+++ b/spec/support/helpers/ask_export_helper.rb
@@ -22,71 +22,44 @@ module AskExportHelper
   def smart_survey_row(options = {})
     environment = options.fetch(:environment, :draft)
     config = AskExport::CONFIG[environment]
-    {
+
+    row = {
       id: options.fetch(:id, random_id),
       survey_id: config[:survey_id],
-      date_ended: options.fetch(:submission_time, Time.zone.now.utc.iso8601),
+      date_started: options.fetch(:start_time, Time.zone.now).utc.iso8601,
+      date_ended: options.fetch(:submission_time, Time.zone.now).utc.iso8601,
       status: options.fetch(:status, "completed"),
-      pages: [
-        {
-          id: random_id,
-          questions: [
-            {
-              id: random_id,
-              title: "Are you 18 or over?",
-              answers: [{ choice_title: "Yes" }],
-            },
-          ],
-        },
-        {
-          id: random_id,
-          questions: [
-            {
-              id: config[:question_field_id],
-              title: "What is your question?",
-              answers: [{ value: options.fetch(:question, "A question?") }],
-            },
-            {
-              id: config[:name_field_id],
-              title: "What is your name?",
-              answers: [{ value: options.fetch(:name, "John Smith") }],
-            },
-            {
-              id: config[:region_field_id],
-              title: "Where do you live?",
-              answers: [{ choice_title: options.fetch(:region, "Yorkshire") }],
-            },
-            {
-              id: config[:email_field_id],
-              title: "What is your email address?",
-              answers: [{ value: options.fetch(:email, "me@example.com") }],
-            },
-            {
-              id: config[:phone_field_id],
-              title: "What is your phone number?",
-              answers: [{ value: options.fetch(:phone, "me@example.com") }],
-            },
-            {
-              id: config[:question_format_field_id],
-              title: "How would you like to ask your question?",
-              answers: [{ choice_title: options.fetch(:question_format, "By video") }],
-            },
-          ],
-        },
-      ],
+      user_agent: options.fetch(:user_agent, "Mozilla/4.5 (compatible; HTTrack 3.0x; Windows 98)"),
+      pages: [smart_survey_age_check_page(options),
+              smart_survey_answers_page(options)].compact,
     }
+
+    if options[:client_id]
+      row[:variables] = [{ id: random_id,
+                           name: "_ga",
+                           label: "clientID",
+                           value: options[:client_id] }]
+    end
+
+    row
   end
 
   def presented_survey_response(options = {})
+    status = options.fetch(:status, "completed")
+    completed = status == "completed"
     {
       id: options.fetch(:id, random_id),
+      client_id: options[:client_id],
+      user_agent: "NCSA Mosaic/3.0 (Windows 95)",
+      status: status,
+      start_time: "01/05/2020 08:55:00",
       submission_time: "01/05/2020 09:00:00",
-      region: options.fetch(:region, "Greater London"),
-      question: "A question?",
-      question_format: "In writing, to be read out at the press conference",
-      name: "Jane Doe",
-      email: "jane@example.com",
-      phone: "+447123456789",
+      region: completed ? options.fetch(:region, "Greater London") : nil,
+      question: completed ? "A question?" : nil,
+      question_format: completed ? "In writing, to be read out at the press conference" : nil,
+      name: completed ? "Jane Doe" : nil,
+      email: completed ? "jane@example.com" : nil,
+      phone: completed ? "+447123456789" : nil,
     }
   end
 
@@ -97,6 +70,66 @@ module AskExportHelper
   end
 
 private
+
+  def smart_survey_age_check_page(options)
+    {
+      id: random_id,
+      questions: [
+        {
+          id: random_id,
+          title: "Are you 18 or over?",
+          answers: [
+            {
+              choice_title: (options[:status] == "disqualified" ? "No" : "Yes"),
+            },
+          ],
+        },
+      ],
+    }
+  end
+
+  def smart_survey_answers_page(options)
+    return if %w[partial disqualified].include?(options[:status])
+
+    environment = options.fetch(:environment, :draft)
+    config = AskExport::CONFIG[environment]
+
+    {
+      id: random_id,
+      questions: [
+        {
+          id: config[:question_field_id],
+          title: "What is your question?",
+          answers: [{ value: options.fetch(:question, "A question?") }],
+        },
+        {
+          id: config[:name_field_id],
+          title: "What is your name?",
+          answers: [{ value: options.fetch(:name, "John Smith") }],
+        },
+        {
+          id: config[:region_field_id],
+          title: "Where do you live?",
+          answers: [{ choice_title: options.fetch(:region, "Yorkshire") }],
+        },
+        {
+          id: config[:email_field_id],
+          title: "What is your email address?",
+          answers: [{ value: options.fetch(:email, "me@example.com") }],
+        },
+        {
+          id: config[:phone_field_id],
+          title: "What is your phone number?",
+          answers: [{ value: options.fetch(:phone, "0789123456") }],
+        },
+        {
+          id: config[:question_format_field_id],
+          title: "How would you like to ask your question?",
+          answers: [{ choice_title: options.fetch(:question_format, "By video") }],
+        },
+      ],
+    }
+  end
 
   def random_id
     rand(0..100_000)


### PR DESCRIPTION
Trello: https://trello.com/c/vk9FZSzS/204-work-out-if-how-we-can-automate-the-data-extraction-and-sharing-of-files

This extends the exporting to produce two additional CSV files: one for Data Labs and one for our teams Performance Analyst. The one for performance analysis produced a bunch of extra complexity as it means downloading the full collection of responses and then filtering to completed for the reports that need this. 

Further details in commits.