### PR TITLE
Fix partial completed submissions

### DIFF
--- a/lib/ask_export/survey_response_fetcher.rb
+++ b/lib/ask_export/survey_response_fetcher.rb
@@ -30,7 +30,7 @@ module AskExport
       loop do
         body = JSON.parse(request_responses(page).body, symbolize_names: true)
 
-        responses += body.map { |entry| ResponsePresenter.call(entry) }
+        responses += body.map { |entry| ResponseSerialiser.call(entry) }
 
         puts "downloaded #{responses.count} responses"
 

--- a/lib/ask_export/survey_response_fetcher/response_serialiser.rb
+++ b/lib/ask_export/survey_response_fetcher/response_serialiser.rb
@@ -43,7 +43,16 @@ module AskExport
       # from Smart Survey with a "completed" status this seems to because
       # Smart Survey enforces required fields only on the client side
       required = %i[region question question_format name email phone]
-      required.any? { |field| answers[field].nil? } ? "partial" : "completed"
+      nil_fields = required.select { |field| answers[field].nil? }
+
+      if nil_fields.any?
+        warn "Response #{response[:id]} has a completed status but has null " \
+             "fields: #{nil_fields.join(', ')}"
+
+        "partial"
+      else
+        "completed"
+      end
     end
 
     def answers

--- a/lib/ask_export/survey_response_fetcher/response_serialiser.rb
+++ b/lib/ask_export/survey_response_fetcher/response_serialiser.rb
@@ -1,5 +1,5 @@
 module AskExport
-  class SurveyResponseFetcher::ResponsePresenter
+  class SurveyResponseFetcher::ResponseSerialiser
     # Consumers of these exports are already accustumed to a particular
     # time formatting, this is retained here so outputs remain consistent
     SMART_SURVEY_TIME_FORMATTING = "%d/%m/%Y %H:%M:%S".freeze

--- a/spec/ask_export/csv_builder_spec.rb
+++ b/spec/ask_export/csv_builder_spec.rb
@@ -1,9 +1,9 @@
 RSpec.describe AskExport::CsvBuilder do
   let(:responses) do
     [
-      presented_survey_response(id: 1, region: "Scotland"),
-      presented_survey_response(id: 2, status: "partial"),
-      presented_survey_response(id: 3, status: "disqualified", client_id: 100),
+      serialised_survey_response(id: 1, region: "Scotland"),
+      serialised_survey_response(id: 2, status: "partial"),
+      serialised_survey_response(id: 3, status: "disqualified", client_id: 100),
     ]
   end
   let(:builder) { described_class.new(stubbed_report(responses: responses)) }

--- a/spec/ask_export/drive_export_spec.rb
+++ b/spec/ask_export/drive_export_spec.rb
@@ -30,9 +30,9 @@ RSpec.describe AskExport::DriveExport do
 
     let(:report) do
       # have a mix of reports to illustrate difference for audiences
-      responses = [presented_survey_response(status: "completed"),
-                   presented_survey_response(status: "completed"),
-                   presented_survey_response(status: "partial")]
+      responses = [serialised_survey_response(status: "completed"),
+                   serialised_survey_response(status: "completed"),
+                   serialised_survey_response(status: "partial")]
       stubbed_report(responses: responses)
     end
 

--- a/spec/ask_export/report_spec.rb
+++ b/spec/ask_export/report_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe AskExport::Report do
   describe "#responses" do
     it "delegates to SurveyResponseFetcher" do
       instance = described_class.new
-      responses = [presented_survey_response]
+      responses = [serialised_survey_response]
       expect(AskExport::SurveyResponseFetcher)
         .to receive(:call)
         .with(instance.since_time, instance.until_time)
@@ -57,9 +57,9 @@ RSpec.describe AskExport::Report do
 
   describe "#completed_responses" do
     it "returns only completed survey responses" do
-      completed_response = presented_survey_response(status: "completed")
-      partial_response = presented_survey_response(status: "partial")
-      disqualified_response = presented_survey_response(status: "disqualified")
+      completed_response = serialised_survey_response(status: "completed")
+      partial_response = serialised_survey_response(status: "partial")
+      disqualified_response = serialised_survey_response(status: "disqualified")
 
       allow(AskExport::SurveyResponseFetcher)
         .to receive(:call)

--- a/spec/ask_export/survey_response_fetcher/response_serialiser_spec.rb
+++ b/spec/ask_export/survey_response_fetcher/response_serialiser_spec.rb
@@ -1,16 +1,16 @@
-RSpec.describe AskExport::SurveyResponseFetcher::ResponsePresenter do
+RSpec.describe AskExport::SurveyResponseFetcher::ResponseSerialiser do
   describe ".call" do
-    it "presents a smart survey response" do
-      presented_response = presented_survey_response
-      options = presented_response.merge(
-        start_time: Time.zone.parse(presented_response[:start_time]),
-        submission_time: Time.zone.parse(presented_response[:submission_time]),
+    it "serialises a smart survey response" do
+      serialised_response = serialised_survey_response
+      options = serialised_response.merge(
+        start_time: Time.zone.parse(serialised_response[:start_time]),
+        submission_time: Time.zone.parse(serialised_response[:submission_time]),
       )
       expect(described_class.call(smart_survey_row(options)))
-        .to eq(presented_response)
+        .to eq(serialised_response)
     end
 
-    it "can present a draft smart survey response" do
+    it "can serialise a draft smart survey response" do
       options = { question: "Draft question?", environment: :draft }
       expect(described_class.call(smart_survey_row(options)))
         .to match(hash_including(question: "Draft question?"))

--- a/spec/ask_export/survey_response_fetcher/response_serialiser_spec.rb
+++ b/spec/ask_export/survey_response_fetcher/response_serialiser_spec.rb
@@ -43,11 +43,16 @@ RSpec.describe AskExport::SurveyResponseFetcher::ResponseSerialiser do
 
     it "rebrands an incomplete 'complete' response as a partial response" do
       row = smart_survey_row(status: "completed",
+                             id: 10,
                              email: nil,
                              phone: nil,
                              question_format: nil)
-      expect(described_class.call(row))
-        .to match(hash_including(status: "partial"))
+      result = nil
+      warning = "Response 10 has a completed status but has null " \
+                "fields: question_format, email, phone\n"
+      expect { result = described_class.call(row) }
+        .to output(warning).to_stderr
+      expect(result).to match(hash_including(status: "partial"))
     end
   end
 end

--- a/spec/ask_export/survey_response_fetcher/response_serialiser_spec.rb
+++ b/spec/ask_export/survey_response_fetcher/response_serialiser_spec.rb
@@ -40,5 +40,14 @@ RSpec.describe AskExport::SurveyResponseFetcher::ResponseSerialiser do
       expect(described_class.call(smart_survey_row(client_id: "947770117.1576778690")))
         .to match(hash_including(client_id: "947770117.1576778690"))
     end
+
+    it "rebrands an incomplete 'complete' response as a partial response" do
+      row = smart_survey_row(status: "completed",
+                             email: nil,
+                             phone: nil,
+                             question_format: nil)
+      expect(described_class.call(row))
+        .to match(hash_including(status: "partial"))
+    end
   end
 end

--- a/spec/ask_export/survey_response_fetcher_spec.rb
+++ b/spec/ask_export/survey_response_fetcher_spec.rb
@@ -31,16 +31,16 @@ RSpec.describe AskExport::SurveyResponseFetcher do
         expect(request).to have_been_made
       end
 
-      it "delegates to ResponsePresenter to serialize the response from Smart Survey" do
+      it "delegates to ResponseSerialiser to serialise the response from Smart Survey" do
         record = smart_survey_row
         stub_smart_survey_api(body: [record])
-        presented_response = presented_survey_response
-        expect(described_class::ResponsePresenter).to receive(:call)
-                                                  .with(record)
-                                                  .and_return(presented_response)
+        serialised_response = serialised_survey_response
+        expect(described_class::ResponseSerialiser).to receive(:call)
+                                                   .with(record)
+                                                   .and_return(serialised_response)
 
         expect(described_class.call(since_time, until_time))
-          .to eql([presented_response])
+          .to eql([serialised_response])
       end
 
       it "requests multiple pages when there are more results than the page size" do

--- a/spec/support/helpers/ask_export_helper.rb
+++ b/spec/support/helpers/ask_export_helper.rb
@@ -8,15 +8,17 @@ module AskExportHelper
       until: options[:until_time]&.to_i&.to_s,
       page: options[:page]&.to_s,
     }.compact
-    body = options.fetch(:body, smart_survey_response(50))
+
+    responses = smart_survey_response(50, environment: environment)
+    body = options.fetch(:body, responses)
 
     stub_request(:get, url)
       .with(query: hash_including(query))
       .to_return(body: JSON.generate(body), status: options.fetch(:status, 200))
   end
 
-  def smart_survey_response(items)
-    items.times.map { smart_survey_row }
+  def smart_survey_response(items, options = {})
+    items.times.map { smart_survey_row(options) }
   end
 
   def smart_survey_row(options = {})

--- a/spec/support/helpers/ask_export_helper.rb
+++ b/spec/support/helpers/ask_export_helper.rb
@@ -72,18 +72,15 @@ module AskExportHelper
 private
 
   def smart_survey_age_check_page(options)
+    choice = options[:status] == "disqualified" ? "No" : "Yes"
+
     {
       id: random_id,
       questions: [
-        {
-          id: random_id,
-          title: "Are you 18 or over?",
-          answers: [
-            {
-              choice_title: (options[:status] == "disqualified" ? "No" : "Yes"),
-            },
-          ],
-        },
+        smart_survey_answer(random_id,
+                            "Are you 18 or over?",
+                            choice,
+                            :choice_title),
       ],
     }
   end
@@ -93,42 +90,41 @@ private
 
     environment = options.fetch(:environment, :draft)
     config = AskExport::CONFIG[environment]
-
     {
       id: random_id,
       questions: [
-        {
-          id: config[:question_field_id],
-          title: "What is your question?",
-          answers: [{ value: options.fetch(:question, "A question?") }],
-        },
-        {
-          id: config[:name_field_id],
-          title: "What is your name?",
-          answers: [{ value: options.fetch(:name, "John Smith") }],
-        },
-        {
-          id: config[:region_field_id],
-          title: "Where do you live?",
-          answers: [{ choice_title: options.fetch(:region, "Yorkshire") }],
-        },
-        {
-          id: config[:email_field_id],
-          title: "What is your email address?",
-          answers: [{ value: options.fetch(:email, "me@example.com") }],
-        },
-        {
-          id: config[:phone_field_id],
-          title: "What is your phone number?",
-          answers: [{ value: options.fetch(:phone, "0789123456") }],
-        },
-        {
-          id: config[:question_format_field_id],
-          title: "How would you like to ask your question?",
-          answers: [{ choice_title: options.fetch(:question_format, "By video") }],
-        },
-      ],
+        smart_survey_answer(config[:question_field_id],
+                            "What is your question?",
+                            options.fetch(:question, "A question?"),
+                            :value),
+        smart_survey_answer(config[:name_field_id],
+                            "What is your name?",
+                            options.fetch(:name, "John Smith"),
+                            :value),
+        smart_survey_answer(config[:region_field_id],
+                            "Where do you live?",
+                            options.fetch(:region, "Yorkshire"),
+                            :choice_title),
+        smart_survey_answer(config[:email_field_id],
+                            "What is your email address?",
+                            options.fetch(:email, "me@example.com"),
+                            :value),
+        smart_survey_answer(config[:phone_field_id],
+                            "What is your phone number?",
+                            options.fetch(:phone, "0789123456"),
+                            :value),
+        smart_survey_answer(config[:question_format_field_id],
+                            "How would you like to ask your question?",
+                            options.fetch(:question_format, "By video"),
+                            :choice_title),
+      ].compact,
     }
+  end
+
+  def smart_survey_answer(id, title, answer, type)
+    return unless answer
+
+    { id: id, title: title, answers: [{ type => answer }] }
   end
 
   def random_id

--- a/spec/support/helpers/ask_export_helper.rb
+++ b/spec/support/helpers/ask_export_helper.rb
@@ -44,7 +44,7 @@ module AskExportHelper
     row
   end
 
-  def presented_survey_response(options = {})
+  def serialised_survey_response(options = {})
     status = options.fetch(:status, "completed")
     completed = status == "completed"
     {
@@ -63,7 +63,7 @@ module AskExportHelper
     }
   end
 
-  def stubbed_report(responses: [presented_survey_response])
+  def stubbed_report(responses: [serialised_survey_response])
     report = AskExport::Report.new
     allow(report).to receive(:responses).and_return(responses)
     report


### PR DESCRIPTION
This resolve an issue we encountered Saturday morning where some of the responses from Smart Survey are marked as "completed" when they are missing required fields. It appears that this can happen because Smart Survey only performs client side validation that fields exist.

The approach taken is to check the responses that are marked as completed and if they are missing any required fields mark them as partial.

More info in the commits.