### PR TITLE
Fix a few concourse things

### DIFF
--- a/concourse.yml
+++ b/concourse.yml
@@ -45,7 +45,7 @@ jobs:
       - set_pipeline: govuk-ask-export
         file: govuk-ask-export/concourse.yml
 
-  - name: scheduled-test-export
+  - name: scheduled-export
     serial: true
     plan:
       - get: export-schedule

--- a/concourse.yml
+++ b/concourse.yml
@@ -45,6 +45,13 @@ jobs:
       - set_pipeline: govuk-ask-export
         file: govuk-ask-export/concourse.yml
 
+  # This task runs each day at 10am and does the following things:
+  #
+  # - Export data from Smart Survey from 10am the previous day until 10 am the
+  #   current day
+  # - Split that into CSV files that are uploaded to Google Drive
+  # - Share those files with Google Drive API and email those users via Notify
+  # - Export performance analyst data to Big Query
   - name: scheduled-export
     serial: true
     plan:

--- a/concourse.yml
+++ b/concourse.yml
@@ -120,7 +120,7 @@ jobs:
       params:
         <<: *live_slack_notification
         text: >
-          :exclamation: The <https://cd.gds-reliability.engineering/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|test export>
+          :exclamation: The <https://cd.gds-reliability.engineering/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|daily export>
           errored. Pinging <!subteam^S0145ESTQE8>.
 
   # This is a test job that can be run any time on demand with test smart survey

--- a/concourse.yml
+++ b/concourse.yml
@@ -135,6 +135,15 @@ jobs:
       - task: drive_export
         config:
           <<: *export_task_config
+          run:
+            dir: govuk-ask-export
+            path: /bin/bash
+            args:
+              - -c
+              - |
+                set -e
+                bundle install --deployment
+                bundle exec rake file_export
           params:
             <<: *common_export_params
             # Do test exports over a long time period because there isn't much data

--- a/concourse.yml
+++ b/concourse.yml
@@ -178,3 +178,41 @@ jobs:
         text: >
           :exclamation: The <https://cd.gds-reliability.engineering/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|test export>
           errored. Pinging <!subteam^S0145ESTQE8>.
+
+  # This task allows exporting the previous days (10am to 10am) data from
+  # Smary Survey to Big Query. It will erase the existing data and replace it.
+  # This task is useful to use if there was a problem with the big query export
+  # and you don't want to run the file export as well.
+  - name: on-demand-biq-query-export
+    serial: true
+    plan:
+      - get: govuk-ask-export
+      - task: big_query_export
+        config: &big_query_export_task_config
+          <<: *export_task_config
+          run:
+            dir: govuk-ask-export
+            path: /bin/bash
+            args:
+              - -c
+              - |
+                set -e
+                bundle install --deployment
+                bundle exec rake big_query_export
+          params:
+            <<: *common_export_params
+            SMART_SURVEY_LIVE: true
+
+  # This task allows you to test running a big query export by using the
+  # Smart Survey draft data and writing to our test Big Query dataset.
+  # Normally there are 0 results in Smart Survey for a single day so this will
+  # likely create an empty table.
+  - name: on-demand-biq-query-test-export
+    serial: true
+    plan:
+      - get: govuk-ask-export
+      - task: big_query_export
+        config:
+          <<: *big_query_export_task_config
+          params:
+            <<: *common_export_params

--- a/concourse.yml
+++ b/concourse.yml
@@ -28,7 +28,7 @@ resources:
       url: https://hooks.slack.com((slack-webhook-path))
 
 common_export_params: &common_export_params
-  GOOGLE_ACCOUNT_TYPE: sevice_account
+  GOOGLE_ACCOUNT_TYPE: service_account
   GOOGLE_CLIENT_ID: ((google-client-id))
   GOOGLE_CLIENT_EMAIL: ((google-client-email))
   GOOGLE_PRIVATE_KEY: ((google-private-key))


### PR DESCRIPTION
Most principally this fixes a spelling error in the concourse file where I put "sevice_account" instead of "service_account".

This also adds a couple of on demand tasks for big query to make testing easier and fixes some other small issues in the concourse.yml file.