### PR TITLE
Add new survey

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ bundle exec rake file_export
 
 The following environment variables should be configured for the task:
 
-- `SMART_SURVEY_LIVE` (optional) - set this to `"true"` to access the live survey,
+- `SMART_SURVEY_CONFIG` (optional) - set this to `"live"` to access the live survey,
   otherwise the draft one will be used.
 - `SMART_SURVEY_API_TOKEN` - accessible via Smart Survey in Account > API Keys
 - `SMART_SURVEY_API_TOKEN_SECRET`
@@ -80,7 +80,7 @@ The following environment variables should be configured for the task:
 Example:
 
 ```
-SMART_SURVEY_LIVE=true SINCE_TIME=09:00 UNTIL_TIME=11:00 SECRET_KEY=$(openssl rand -hex 64) SMART_SURVEY_API_TOKEN=<api-token> SMART_SURVEY_API_TOKEN_SECRET=<api-token-secret> bundle exec rake file_export
+SMART_SURVEY_CONFIG=live SINCE_TIME=09:00 UNTIL_TIME=11:00 SECRET_KEY=$(openssl rand -hex 64) SMART_SURVEY_API_TOKEN=<api-token> SMART_SURVEY_API_TOKEN_SECRET=<api-token-secret> bundle exec rake file_export
 ```
 
 ## Licence

--- a/concourse.yml
+++ b/concourse.yml
@@ -79,7 +79,7 @@ jobs:
             UNTIL_TIME: 00:00
             SMART_SURVEY_API_TOKEN: ((smart-survey-api-token))
             SMART_SURVEY_API_TOKEN_SECRET: ((smart-survey-api-token-secret))
-            SMART_SURVEY_LIVE: true
+            SMART_SURVEY_CONFIG: live_version_2
             GOOGLE_ACCOUNT_TYPE: service_account
             GOOGLE_CLIENT_ID: ((google-client-id))
             GOOGLE_CLIENT_EMAIL: ((google-client-email))

--- a/lib/ask_export.rb
+++ b/lib/ask_export.rb
@@ -24,10 +24,19 @@ module AskExport
       email_field_id: 11289069,
       phone_field_id: 11312922,
     },
+    live_version_2: {
+      survey_id: 845945,
+      region_field_id: 12808286,
+      question_field_id: 12808290,
+      question_format_field_id: 12808730,
+      name_field_id: 12808285,
+      email_field_id: 12808288,
+      phone_field_id: 12808287,
+    },
   }.freeze
 
   def self.config(item)
-    environment = ENV["SMART_SURVEY_LIVE"] == "true" ? :live : :draft
+    environment = ENV.fetch("SMART_SURVEY_CONFIG", "draft").to_sym
     CONFIG[environment].fetch(item)
   end
 end

--- a/spec/ask_export/survey_response_fetcher_spec.rb
+++ b/spec/ask_export/survey_response_fetcher_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe AskExport::SurveyResponseFetcher do
 
       it "can use the live environment" do
         live_request = stub_smart_survey_api(environment: :live)
-        ClimateControl.modify(SMART_SURVEY_LIVE: "true") do
+        ClimateControl.modify(SMART_SURVEY_CONFIG: "live") do
           described_class.call(since_time, until_time)
         end
         expect(live_request).to have_been_made


### PR DESCRIPTION
This adds support to export data for the new survey, "live_version_2". In doing so the SMART_SURVEY_LIVE env var has been renamed to SMART_SURVEY_CONFIG. Its value to should be the name of the config you wish to use.