### PR TITLE
Fix automated export pipelines

### DIFF
--- a/concourse.yml
+++ b/concourse.yml
@@ -84,6 +84,7 @@ jobs:
             GOOGLE_CLIENT_ID: ((google-client-id))
             GOOGLE_CLIENT_EMAIL: ((google-client-email))
             GOOGLE_PRIVATE_KEY: ((google-private-key))
+            GOOGLE_CLOUD_PROJECT: ((google-cloud-project))
             FOLDER_ID_CABINET_OFFICE: ((google-drive-folder-id-cabinet-office))
             FOLDER_ID_DATA_LABS: ((google-drive-folder-id-data-labs))
             FOLDER_ID_PERFORMANCE_ANALYST: ((google-drive-folder-id-performance-analyst))

--- a/config/pipelines.yml
+++ b/config/pipelines.yml
@@ -2,7 +2,6 @@
 pipelines:
   cabinet-office:
     destinations:
-      - local_filesystem
       - google_drive
     only_completed: true
     fields:
@@ -13,31 +12,8 @@ pipelines:
       - email
       - phone
       - question_format
-  data-labs:
-    destinations:
-      - local_filesystem
-    only_completed: true
-    fields:
-      - submission_time
-      - region
-      - question
-      - question_format
-      - hashed_email
-      - hashed_phone
-  performance-analyst:
-    destinations:
-      - local_filesystem
-    only_completed: false
-    fields:
-      - start_time
-      - submission_time
-      - status
-      - user_agent
-      - client_id
-      - region
   third-party:
     destinations:
-      - local_filesystem
       - google_drive
     only_completed: true
     fields:
@@ -47,9 +23,7 @@ pipelines:
       - question
       - question_format
   gcs-public-questions:
-    destinations:
-      - local_filesystem
-      - aws_s3
+    destinations: []
     only_completed: true
     fields:
       - submission_time

--- a/spec/integration/file_export_spec.rb
+++ b/spec/integration/file_export_spec.rb
@@ -15,9 +15,9 @@ RSpec.describe "File export" do
     stub_drive_authentication
 
     expected_exports = {
-      local_filesystem: %w[cabinet-office data-labs performance-analyst third-party gcs-public-questions],
+      local_filesystem: [],
       google_drive: %w[cabinet-office third-party],
-      aws_s3: %w[gcs-public-questions],
+      aws_s3: [],
     }
 
     google_drive_stubs = expected_exports[:google_drive].map do |recipient|


### PR DESCRIPTION
This add the missing GOOGLE_CLOUD_PROJECT env var from concourse and removes unused pipeline and export destinations.