### PR TITLE
Remove unused code

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,6 @@ The following environment variables should be configured for the task:
   otherwise the draft one will be used.
 - `SMART_SURVEY_API_TOKEN` - accessible via Smart Survey in Account > API Keys
 - `SMART_SURVEY_API_TOKEN_SECRET`
-- `SECRET_KEY` - a key that is used as salt to hashing functions to anonymise
-  personally identifiable information
 - `SINCE_TIME` - defaults to "10:00", can be changed to alter the time
   exports include data from. When this is a relative time (for example "10:00") it
   will be for the previous day, otherwise an absolute time can be set (for example
@@ -80,7 +78,7 @@ The following environment variables should be configured for the task:
 Example:
 
 ```
-SMART_SURVEY_CONFIG=live SINCE_TIME=09:00 UNTIL_TIME=11:00 SECRET_KEY=$(openssl rand -hex 64) SMART_SURVEY_API_TOKEN=<api-token> SMART_SURVEY_API_TOKEN_SECRET=<api-token-secret> bundle exec rake run_exports
+SMART_SURVEY_CONFIG=live SINCE_TIME=09:00 UNTIL_TIME=11:00 SMART_SURVEY_API_TOKEN=<api-token> SMART_SURVEY_API_TOKEN_SECRET=<api-token-secret> bundle exec rake run_exports
 ```
 
 ## Licence

--- a/concourse.yml
+++ b/concourse.yml
@@ -72,7 +72,6 @@ jobs:
                 bundle install --deployment
                 bundle exec rake run_exports
           params:
-            SECRET_KEY: ((secret-key))
             SINCE_TIME: 00:00
             UNTIL_TIME: 00:00
             SMART_SURVEY_API_TOKEN: ((smart-survey-api-token))

--- a/config/pipelines.yml
+++ b/config/pipelines.yml
@@ -25,6 +25,6 @@ pipelines:
       - aws_s3
     only_completed: true
     fields:
-      - submission_time
+      - end_time
       - region
       - question

--- a/spec/ask_export/report_builder_spec.rb
+++ b/spec/ask_export/report_builder_spec.rb
@@ -1,6 +1,4 @@
 RSpec.describe AskExport::ReportBuilder do
-  let(:secret_key) { "secret" }
-
   around do |example|
     travel_to(Time.zone.parse("2020-05-01 12:00")) { example.run }
   end
@@ -49,7 +47,7 @@ RSpec.describe AskExport::ReportBuilder do
     it "delegates to SurveyResponseFetcher" do
       instance = described_class.new
       responses = [serialised_survey_response({ id: 1 })]
-      expected_responses = [report_response({ id: 1, question: "REDACTED1" }, secret_key)]
+      expected_responses = [report_response({ id: 1, question: "REDACTED1" })]
 
       expect(AskExport::SurveyResponseFetcher)
         .to receive(:call)
@@ -58,9 +56,7 @@ RSpec.describe AskExport::ReportBuilder do
 
       stub_deidentify(1)
 
-      ClimateControl.modify(SECRET_KEY: secret_key) do
-        expect(instance.responses).to eq(expected_responses)
-      end
+      expect(instance.responses).to eq(expected_responses)
     end
   end
 
@@ -72,7 +68,7 @@ RSpec.describe AskExport::ReportBuilder do
         serialised_survey_response(status: "disqualified"),
       ]
 
-      expected_responses = [report_response({ id: 1, question: "REDACTED1" }, secret_key)]
+      expected_responses = [report_response({ id: 1, question: "REDACTED1" })]
 
       allow(AskExport::SurveyResponseFetcher)
         .to receive(:call)
@@ -80,9 +76,7 @@ RSpec.describe AskExport::ReportBuilder do
 
       stub_deidentify(3)
 
-      ClimateControl.modify(SECRET_KEY: secret_key) do
-        expect(described_class.new.completed_responses).to eq(expected_responses)
-      end
+      expect(described_class.new.completed_responses).to eq(expected_responses)
     end
   end
 
@@ -103,7 +97,7 @@ RSpec.describe AskExport::ReportBuilder do
     end
 
     it "returns a report with only completed responses" do
-      expected_responses = [report_response({ id: 1, question: "REDACTED1" }, secret_key)]
+      expected_responses = [report_response({ id: 1, question: "REDACTED1" })]
 
       expect(AskExport::Report).to receive(:new)
         .with(
@@ -112,15 +106,13 @@ RSpec.describe AskExport::ReportBuilder do
           Time.zone.parse("2020-05-01 10:00"),
         )
 
-      ClimateControl.modify(SECRET_KEY: secret_key) do
-        described_class.new.build(true)
-      end
+      described_class.new.build(true)
     end
 
     it "returns a report with all responses" do
       expected_responses = [
-        report_response({ id: 1, question: "REDACTED1" }, secret_key),
-        report_response({ status: "partial", id: 2, question: "REDACTED2" }, secret_key),
+        report_response({ id: 1, question: "REDACTED1" }),
+        report_response({ status: "partial", id: 2, question: "REDACTED2" }),
       ]
 
       expect(AskExport::Report).to receive(:new)
@@ -130,9 +122,7 @@ RSpec.describe AskExport::ReportBuilder do
           Time.zone.parse("2020-05-01 10:00"),
         )
 
-      ClimateControl.modify(SECRET_KEY: secret_key) do
-        described_class.new.build(false)
-      end
+      described_class.new.build(false)
     end
   end
 

--- a/spec/ask_export/report_builder_spec.rb
+++ b/spec/ask_export/report_builder_spec.rb
@@ -46,8 +46,8 @@ RSpec.describe AskExport::ReportBuilder do
   describe "#responses" do
     it "delegates to SurveyResponseFetcher" do
       instance = described_class.new
-      responses = [serialised_survey_response({ id: 1 })]
-      expected_responses = [report_response({ id: 1, question: "REDACTED1" })]
+      responses = [serialised_survey_response(id: 1)]
+      expected_responses = [serialised_survey_response(id: 1, question: "REDACTED1")]
 
       expect(AskExport::SurveyResponseFetcher)
         .to receive(:call)
@@ -68,7 +68,7 @@ RSpec.describe AskExport::ReportBuilder do
         serialised_survey_response(status: "disqualified"),
       ]
 
-      expected_responses = [report_response({ id: 1, question: "REDACTED1" })]
+      expected_responses = [serialised_survey_response(id: 1, question: "REDACTED1")]
 
       allow(AskExport::SurveyResponseFetcher)
         .to receive(:call)
@@ -92,12 +92,11 @@ RSpec.describe AskExport::ReportBuilder do
       allow(AskExport::SurveyResponseFetcher)
         .to receive(:call)
         .and_return(responses)
-
-      stub_deidentify(2)
     end
 
     it "returns a report with only completed responses" do
-      expected_responses = [report_response({ id: 1, question: "REDACTED1" })]
+      expected_responses = [serialised_survey_response(id: 1, question: "REDACTED1")]
+      stub_deidentify(2)
 
       expect(AskExport::Report).to receive(:new)
         .with(
@@ -111,9 +110,10 @@ RSpec.describe AskExport::ReportBuilder do
 
     it "returns a report with all responses" do
       expected_responses = [
-        report_response({ id: 1, question: "REDACTED1" }),
-        report_response({ status: "partial", id: 2, question: "REDACTED2" }),
+        serialised_survey_response(id: 1, question: "REDACTED1"),
+        serialised_survey_response(status: "partial", id: 2),
       ]
+      stub_deidentify(1)
 
       expect(AskExport::Report).to receive(:new)
         .with(

--- a/spec/ask_export/report_spec.rb
+++ b/spec/ask_export/report_spec.rb
@@ -1,9 +1,9 @@
 RSpec.describe AskExport::Report do
   let(:responses) do
     [
-      report_response(id: 1, region: "Scotland"),
-      report_response(id: 2, status: "partial"),
-      report_response(id: 3, status: "disqualified"),
+      serialised_survey_response(id: 1, region: "Scotland"),
+      serialised_survey_response(id: 2, status: "partial"),
+      serialised_survey_response(id: 3, status: "disqualified"),
     ]
   end
 

--- a/spec/ask_export/report_spec.rb
+++ b/spec/ask_export/report_spec.rb
@@ -10,13 +10,13 @@ RSpec.describe AskExport::Report do
   describe "#to_csv" do
     it "returns the responses formatted as a CSV" do
       report = described_class.new(responses, nil, nil)
-      fields = %i[submission_time status user_agent region]
+      fields = %i[end_time status user_agent region]
 
       expect(report.to_csv(fields)).to eq(
-        "submission_time,status,user_agent,region\n" \
-        "01/05/2020 09:00:00,completed,NCSA Mosaic/3.0 (Windows 95),Scotland\n" \
-        "01/05/2020 09:00:00,partial,NCSA Mosaic/3.0 (Windows 95),\n" \
-        "01/05/2020 09:00:00,disqualified,NCSA Mosaic/3.0 (Windows 95),\n",
+        "end_time,status,user_agent,region\n" \
+        "2020-05-01 09:00:00 +0100,completed,NCSA Mosaic/3.0 (Windows 95),Scotland\n" \
+        "2020-05-01 09:00:00 +0100,partial,NCSA Mosaic/3.0 (Windows 95),\n" \
+        "2020-05-01 09:00:00 +0100,disqualified,NCSA Mosaic/3.0 (Windows 95),\n",
       )
     end
   end

--- a/spec/integration/file_export_spec.rb
+++ b/spec/integration/file_export_spec.rb
@@ -29,7 +29,6 @@ RSpec.describe "File export" do
       ClimateControl.modify(SMART_SURVEY_API_TOKEN: "token",
                             SMART_SURVEY_API_TOKEN_SECRET: "token",
                             OUTPUT_DIR: tmpdir,
-                            SECRET_KEY: SecureRandom.uuid,
                             SINCE_TIME: "2020-05-06 20:00",
                             UNTIL_TIME: "2020-05-07 11:00",
                             GOOGLE_CLOUD_PROJECT: "project-name",

--- a/spec/support/helpers/smart_survey_helper.rb
+++ b/spec/support/helpers/smart_survey_helper.rb
@@ -57,20 +57,12 @@ module SmartSurveyHelper
       start_time: Time.zone.parse("2020-05-01 08:55:00+01Z"),
       end_time: Time.zone.parse("2020-05-01 09:00:00+01Z"),
       region: completed ? options.fetch(:region, "Greater London") : nil,
-      question: completed ? "A question?" : nil,
+      question: completed ? options.fetch(:question, "A question?") : nil,
       share_video: completed ? "Yes" : nil,
       name: completed ? "Jane Doe" : nil,
       email: completed ? "jane@example.com" : nil,
       phone: completed ? "+447123456789" : nil,
     }
-  end
-
-  def report_response(options = {})
-    response = serialised_survey_response(options)
-
-    response.merge({
-      question: options[:question],
-    }.compact)
   end
 
   def stubbed_report(responses: [serialised_survey_response])

--- a/spec/support/helpers/smart_survey_helper.rb
+++ b/spec/support/helpers/smart_survey_helper.rb
@@ -54,8 +54,8 @@ module SmartSurveyHelper
       client_id: options[:client_id],
       user_agent: "NCSA Mosaic/3.0 (Windows 95)",
       status: status,
-      start_time: Time.zone.parse("2020-05-01 08:55:00"),
-      end_time: Time.zone.parse("2020-05-01 09:00:00"),
+      start_time: Time.zone.parse("2020-05-01 08:55:00+01Z"),
+      end_time: Time.zone.parse("2020-05-01 09:00:00+01Z"),
       region: completed ? options.fetch(:region, "Greater London") : nil,
       question: completed ? "A question?" : nil,
       share_video: completed ? "Yes" : nil,
@@ -65,18 +65,11 @@ module SmartSurveyHelper
     }
   end
 
-  def report_response(options = {}, secret_key = "")
+  def report_response(options = {})
     response = serialised_survey_response(options)
-
-    status = options.fetch(:status, "completed")
-    completed = status == "completed"
 
     response.merge({
       question: options[:question],
-      start_time: "01/05/2020 08:55:00",
-      submission_time: "01/05/2020 09:00:00",
-      hashed_email: completed ? Digest::SHA256.hexdigest("jane@example.com" + secret_key) : nil,
-      hashed_phone: completed ? Digest::SHA256.hexdigest("+447123456789" + secret_key) : nil,
     }.compact)
   end
 


### PR DESCRIPTION
This removes code that added hash versions of the phone and email address and formatted the start and end time. These extra fields and formatting is no longer required.

This also remove associated test helpers.