### PR TITLE
Add lazy loading and caching to targets

### DIFF
--- a/lib/ask_export/pipeline.rb
+++ b/lib/ask_export/pipeline.rb
@@ -23,19 +23,10 @@ module AskExport
       data = report.to_csv(fields)
 
       targets.each do |target_name|
-        target = fetch_target(target_name)
+        target = Targets.find(target_name)
 
         target.export(name, filename, data)
       end
-    end
-
-  private
-
-    def fetch_target(name)
-      target = Targets.load_all[name]
-      raise "Export target #{name} not found" unless target
-
-      target
     end
   end
 end

--- a/lib/ask_export/targets/targets.rb
+++ b/lib/ask_export/targets/targets.rb
@@ -1,11 +1,22 @@
 module AskExport
   module Targets
-    def self.load_all
-      {
-        "aws_s3" => AwsS3.new,
-        "google_drive" => GoogleDrive.new,
-        "filesystem" => Filesystem.new,
-      }
+    ALL = {
+      "aws_s3" => AwsS3,
+      "google_drive" => GoogleDrive,
+      "filesystem" => Filesystem,
+    }.freeze
+
+    @target_cache = {}
+
+    def self.find(name)
+      @target_cache[name] ||= begin
+        target_class = ALL[name]
+        target = target_class.new if target_class
+
+        raise "Export target #{name} not found" unless target
+
+        target
+      end
     end
   end
 end

--- a/spec/ask_export/pipeline_spec.rb
+++ b/spec/ask_export/pipeline_spec.rb
@@ -38,15 +38,12 @@ RSpec.describe AskExport::Pipeline do
   end
 
   describe "#run" do
-    let(:targets) do
-      {
-        "target_a" => spy("TargetA"),
-        "target_b" => spy("TargetB"),
-      }
-    end
+    let(:target_a) { spy("TargetA") }
+    let(:target_b) { spy("TargetB") }
 
     before do
-      allow(AskExport::Targets).to receive(:load_all).and_return(targets)
+      allow(AskExport::Targets).to receive(:find).with("target_a").and_return(target_a)
+      allow(AskExport::Targets).to receive(:find).with("target_b").and_return(target_b)
 
       @report_builder = instance_double("AskExport::ReportBuilder")
 
@@ -68,8 +65,8 @@ RSpec.describe AskExport::Pipeline do
 
       pipeline.run(@report_builder)
 
-      expect(targets["target_a"]).to have_received(:export).with("pipeline-a", "file-a.csv", "completed-data")
-      expect(targets["target_b"]).to have_received(:export).with("pipeline-a", "file-a.csv", "completed-data")
+      expect(target_a).to have_received(:export).with("pipeline-a", "file-a.csv", "completed-data")
+      expect(target_b).to have_received(:export).with("pipeline-a", "file-a.csv", "completed-data")
     end
   end
 end

--- a/spec/ask_export/targets/targets_spec.rb
+++ b/spec/ask_export/targets/targets_spec.rb
@@ -1,24 +1,39 @@
 RSpec.describe AskExport::Targets do
-  describe "#load_all" do
-    it "returns a hash containing all targets" do
-      expected_targets = {}
+  describe "#find" do
+    let(:target_a1) { double("target_al") }
+    let(:target_b1) { double("target_bl") }
 
-      AskExport::Targets.constants.each do |target|
-        dummy_target = double(target.to_s)
-        allow(AskExport::Targets.const_get(target)).to receive(:new)
-          .and_return(dummy_target)
+    before do
+      target_classes = {
+        "target_a" => double("TargetA"),
+        "target_b" => double("TargetB"),
+      }
 
-        underscored_name = target.to_s
-          .gsub(/([A-Z]+)([A-Z][a-z])/, '\1_\2')
-          .gsub(/([a-z\d])([A-Z])/, '\1_\2')
-          .downcase
+      allow(target_classes["target_a"]).to receive(:new)
+        .and_return(target_a1, double("target_a2"))
 
-        expected_targets[underscored_name] = dummy_target
-      end
+      allow(target_classes["target_b"]).to receive(:new)
+        .and_return(target_b1, double("target_b2"))
 
-      targets = AskExport::Targets.load_all
+      stub_const("AskExport::Targets::ALL", target_classes)
+    end
 
-      expect(targets).to eq(expected_targets)
+    it "returns the named target object" do
+      target = AskExport::Targets.find("target_a")
+
+      expect(target).to eq(target_a1)
+    end
+
+    it "returns the same named target object on multiple calls" do
+      AskExport::Targets.find("target_b")
+      target = AskExport::Targets.find("target_b")
+
+      expect(target).to eq(target_b1)
+    end
+
+    it "raises a error if target not available" do
+      expect { AskExport::Targets.find("target_c") }
+        .to raise_error("Export target target_c not found")
     end
   end
 end


### PR DESCRIPTION
This prevents targets from being loaded if they aren't used and to only be loaded once if needed.