### PR TITLE
Add automatic deletion of old or partial responses

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -19,3 +19,23 @@ task :run_exports do
 
   pipelines.each { |pipeline| pipeline.run(report_builder) }
 end
+
+desc "Delete old user data from Smart Survey"
+task :delete_data do
+  survey_id = AskExport.config(:survey_id)
+  client = SmartSurvey::Client.new
+
+  # Delete responses over 3 months old as per privacy agreement
+  old_responses = client.list_responses(survey_id: survey_id, until_time: 3.months.ago)
+
+  old_responses.each do |response|
+    client.delete_response(survey_id: survey_id, response_id: response.id)
+  end
+
+  # Delete partial filled responses as they cannot be used
+  partial_responses = client.list_responses(survey_id: survey_id, completed: 0)
+
+  partial_responses.each do |response|
+    client.delete_response(survey_id: survey_id, response_id: response.id)
+  end
+end

--- a/Rakefile
+++ b/Rakefile
@@ -26,16 +26,20 @@ task :delete_data do
   client = SmartSurvey::Client.new
 
   # Delete responses over 3 months old as per privacy agreement
+  p "Deleting responses over 3 months old"
   old_responses = client.list_responses(survey_id: survey_id, until_time: 3.months.ago)
 
-  old_responses.each do |response|
+  old_responses.each.with_index(1) do |response, index|
     client.delete_response(survey_id: survey_id, response_id: response.id)
+    p "Deleted #{index} responses" if (index % 50).zero?
   end
 
   # Delete partial filled responses as they cannot be used
+  p "Deleting partially filled responses"
   partial_responses = client.list_responses(survey_id: survey_id, completed: 0)
 
-  partial_responses.each do |response|
+  partial_responses.each.with_index(1) do |response, index|
     client.delete_response(survey_id: survey_id, response_id: response.id)
+    p "Deleted #{index} responses" if (index % 50).zero?
   end
 end

--- a/concourse.yml
+++ b/concourse.yml
@@ -71,6 +71,7 @@ jobs:
                 set -e
                 bundle install --deployment
                 bundle exec rake run_exports
+                bundle exec rake delete_data
           params:
             SINCE_TIME: 00:00
             UNTIL_TIME: 00:00

--- a/lib/ask_export/report_builder.rb
+++ b/lib/ask_export/report_builder.rb
@@ -16,7 +16,10 @@ module AskExport
       @responses ||= begin
         survey_id = AskExport.config(:survey_id)
         raw_responses = SmartSurvey::Client.new.list_responses(
-          survey_id, since_time, until_time, AskExport::Response
+          survey_id: survey_id,
+          response_class: AskExport::Response,
+          since_time: since_time,
+          until_time: until_time,
         )
 
         post_process(raw_responses)

--- a/lib/smart_survey/client.rb
+++ b/lib/smart_survey/client.rb
@@ -48,6 +48,10 @@ module SmartSurvey
       responses
     end
 
+    def delete_response(survey_id:, response_id:)
+      @conn.delete("surveys/#{survey_id}/responses/#{response_id}")
+    end
+
   private
 
     def api_token

--- a/spec/ask_export/report_builder_spec.rb
+++ b/spec/ask_export/report_builder_spec.rb
@@ -52,7 +52,10 @@ RSpec.describe AskExport::ReportBuilder do
 
       allow(SmartSurvey::Client).to receive(:new).and_return(client)
       allow(client).to receive(:list_responses)
-        .with(849_813, instance.since_time, instance.until_time, AskExport::Response)
+        .with(survey_id: 849_813,
+              response_class: AskExport::Response,
+              since_time: instance.since_time,
+              until_time: instance.until_time)
         .and_return(responses)
 
       stub_deidentify(1)

--- a/spec/integration/delete_data_spec.rb
+++ b/spec/integration/delete_data_spec.rb
@@ -1,0 +1,35 @@
+RSpec.describe "Delete data" do
+  around do |example|
+    freeze_time { example.run }
+  end
+
+  it "fetches surveys and creates files for them" do
+    survey_id = AskExport.config(:survey_id)
+
+    old_responses = ask_smart_survey_responses(
+      2, { date_ended: 4.months.ago }
+    )
+
+    old_responses_requests = stub_get_responses(
+      survey_id, old_responses.dup, { until_time: 3.months.ago }
+    )
+
+    partial_responses = ask_smart_survey_responses(2, { status: "partial" })
+
+    partial_responses_requests = stub_get_responses(
+      survey_id, partial_responses.dup, { completed: "0" }
+    )
+
+    delete_requests = (old_responses + partial_responses).map do |response|
+      stub_delete_response(survey_id, response[:id])
+    end
+
+    ClimateControl.modify(SMART_SURVEY_API_TOKEN: "token",
+                          SMART_SURVEY_API_TOKEN_SECRET: "token") do
+      Rake::Task["delete_data"].invoke
+    end
+
+    all_requests = old_responses_requests + partial_responses_requests + delete_requests
+    all_requests.each { |request| expect(request).to have_been_made }
+  end
+end

--- a/spec/integration/run_exports_spec.rb
+++ b/spec/integration/run_exports_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe "File export" do
 
   let!(:smart_survey_request) do
     survey_id = AskExport.config(:survey_id)
-    stub_get_responses(survey_id, 50).first
+    responses = ask_smart_survey_responses(50)
+    stub_get_responses(survey_id, responses).first
   end
 
   it "fetches surveys and creates files for them" do

--- a/spec/integration/run_exports_spec.rb
+++ b/spec/integration/run_exports_spec.rb
@@ -5,11 +5,14 @@ RSpec.describe "File export" do
     expect { example.run }.to output.to_stdout
   end
 
-  let!(:smart_survey_request) { stub_smart_survey_api }
+  let!(:smart_survey_request) do
+    survey_id = AskExport.config(:survey_id)
+    stub_get_responses(survey_id, 50).first
+  end
 
   it "fetches surveys and creates files for them" do
     dlp_client = stub_dlp_client
-    expect_deidentify_to_called(dlp_client, ["A question?"] * 50, ["A question?"] * 50)
+    expect_deidentify_to_called(dlp_client, [match(/Answer/)] * 50, ["A question?"] * 50)
 
     s3_client = stub_aws_s3_client
     stub_drive_authentication

--- a/spec/smart_survey/client_spec.rb
+++ b/spec/smart_survey/client_spec.rb
@@ -16,7 +16,10 @@ RSpec.describe SmartSurvey::Client do
     let(:until_time) { Time.zone.parse("2020-05-01 10:00") }
 
     it "make the requests with correct parameters" do
-      requests = stub_get_responses(survey_id, 200, since_time: since_time, until_time: until_time)
+      responses = smart_survey_responses(200)
+      requests = stub_get_responses(
+        survey_id, responses, since_time: since_time, until_time: until_time
+      )
 
       client.list_responses(
         survey_id: survey_id, since_time: since_time, until_time: until_time,
@@ -26,7 +29,7 @@ RSpec.describe SmartSurvey::Client do
     end
 
     it "returns an array of responses" do
-      stub_get_responses(survey_id, 2)
+      stub_get_responses(survey_id, smart_survey_responses(2))
       responses = client.list_responses(survey_id: survey_id)
 
       expect(responses).to contain_exactly(
@@ -36,14 +39,15 @@ RSpec.describe SmartSurvey::Client do
     end
 
     it "can retreive more responses than maximum page size of 100" do
-      stub_get_responses(survey_id, 250)
+      stub_get_responses(survey_id, smart_survey_responses(250))
       responses = client.list_responses(survey_id: survey_id)
 
       expect(responses.count).to eq(250)
     end
 
     it "sleeps between each request" do
-      stub_get_responses(survey_id, 250)
+      stub_get_responses(survey_id, smart_survey_responses(250))
+
       expect_any_instance_of(described_class).to receive(:sleep).twice
       client.list_responses(survey_id: survey_id)
     end

--- a/spec/smart_survey/client_spec.rb
+++ b/spec/smart_survey/client_spec.rb
@@ -16,14 +16,17 @@ RSpec.describe SmartSurvey::Client do
 
     it "make the requests with correct parameters" do
       requests = stub_get_responses(survey_id, 200, since_time: since_time, until_time: until_time)
-      client.list_responses(survey_id, since_time, until_time)
+
+      client.list_responses(
+        survey_id: survey_id, since_time: since_time, until_time: until_time,
+      )
 
       requests.each { |request| expect(request).to have_been_made }
     end
 
     it "returns an array of responses" do
       stub_get_responses(survey_id, 2)
-      responses = client.list_responses(survey_id, since_time, until_time)
+      responses = client.list_responses(survey_id: survey_id)
 
       expect(responses).to contain_exactly(
         an_instance_of(SmartSurvey::Response),
@@ -33,7 +36,7 @@ RSpec.describe SmartSurvey::Client do
 
     it "can retreive more responses than maximum page size of 100" do
       stub_get_responses(survey_id, 250)
-      responses = client.list_responses(survey_id, since_time, until_time)
+      responses = client.list_responses(survey_id: survey_id)
 
       expect(responses.count).to eq(250)
     end
@@ -41,7 +44,7 @@ RSpec.describe SmartSurvey::Client do
     it "sleeps between each request" do
       stub_get_responses(survey_id, 250)
       expect_any_instance_of(described_class).to receive(:sleep).twice
-      client.list_responses(survey_id, since_time, until_time)
+      client.list_responses(survey_id: survey_id)
     end
   end
 end

--- a/spec/smart_survey/client_spec.rb
+++ b/spec/smart_survey/client_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe SmartSurvey::Client do
-  describe "#list_response" do
+  describe "#list_responses" do
     before do
       allow_any_instance_of(described_class).to receive(:sleep)
       allow_any_instance_of(Faraday::Request::Retry).to receive(:sleep)

--- a/spec/smart_survey/client_spec.rb
+++ b/spec/smart_survey/client_spec.rb
@@ -1,4 +1,7 @@
 RSpec.describe SmartSurvey::Client do
+  let(:survey_id) { "123456789" }
+  let(:client) { described_class.new }
+
   describe "#list_responses" do
     before do
       allow_any_instance_of(described_class).to receive(:sleep)
@@ -11,8 +14,6 @@ RSpec.describe SmartSurvey::Client do
 
     let(:since_time) { Time.zone.parse("2020-04-30 10:00") }
     let(:until_time) { Time.zone.parse("2020-05-01 10:00") }
-    let(:survey_id) { "123456789" }
-    let(:client) { described_class.new }
 
     it "make the requests with correct parameters" do
       requests = stub_get_responses(survey_id, 200, since_time: since_time, until_time: until_time)
@@ -45,6 +46,17 @@ RSpec.describe SmartSurvey::Client do
       stub_get_responses(survey_id, 250)
       expect_any_instance_of(described_class).to receive(:sleep).twice
       client.list_responses(survey_id: survey_id)
+    end
+  end
+
+  describe "#delete_response" do
+    it "makes request with correct parameters" do
+      response_id = "987654321"
+      request = stub_delete_response(survey_id, response_id)
+
+      client.delete_response(survey_id: survey_id, response_id: response_id)
+
+      expect(request).to have_been_made
     end
   end
 end

--- a/spec/support/helpers/smart_survey_helper.rb
+++ b/spec/support/helpers/smart_survey_helper.rb
@@ -5,7 +5,7 @@ module SmartSurveyHelper
     query = {
       since: options[:since_time]&.to_i&.to_s,
       until: options[:until_time]&.to_i&.to_s,
-    }.compact
+    }.merge(auth_parameters).compact
 
     max_page_size = options.fetch(:page_size, 100)
     page = 1
@@ -28,6 +28,27 @@ module SmartSurveyHelper
     end
 
     requests
+  end
+
+  def stub_delete_response(survey_id, response_id)
+    url = "https://api.smartsurvey.io/v1/surveys/#{survey_id}/responses/#{response_id}"
+
+    body = "{
+      \"status\": 200,
+      \"code\": \"success\",
+      \"message\": \"Survey response has been deleted.\"
+    }"
+
+    stub_request(:delete, url)
+      .with(query: hash_including(auth_parameters))
+      .to_return(body: body, status: 200)
+  end
+
+  def auth_parameters
+    {
+      "api_token" => anything,
+      "api_token_secret" => anything,
+    }
   end
 
   def ask_smart_survey_responses(count, options = {})


### PR DESCRIPTION
This expands the SmartSurvey API client to handle delete response request and adds a extra step in the daily task to delete responses that are more the 3 months old (as per our privacy agreement) and partial responses (as we only use completed responses). 