### PR TITLE
Update slack channel for concourse notifications

### DIFF
--- a/concourse.yml
+++ b/concourse.yml
@@ -1,6 +1,6 @@
 ---
 slack_settings: &slack_settings
-  channel: '#govuk-smart-answers-devs'
+  channel: '#coronavirus-services-developer-only'
   username: GOV.UK Ask Export
   icon_emoji: ':concourse:'
   silent: true


### PR DESCRIPTION
This changes the destination for slack notification, as we've recently restructured teams.