### PR TITLE
Add cleanup task to delete files in Google Drive

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -43,3 +43,11 @@ task :delete_data do
     p "Deleted #{index} responses" if (index % 50).zero?
   end
 end
+
+desc "Delete data for pipeline targets"
+task :run_cleanup do
+  config_path = File.expand_path("config/pipelines.yml", __dir__)
+  pipelines = AskExport::Pipeline.load_all(config_path)
+
+  pipelines.each(&:cleanup)
+end

--- a/lib/ask_export/pipeline.rb
+++ b/lib/ask_export/pipeline.rb
@@ -28,5 +28,13 @@ module AskExport
         target.export(name, filename, data)
       end
     end
+
+    def cleanup
+      targets.each do |target_name|
+        target = Targets.find(target_name)
+
+        target.cleanup(name)
+      end
+    end
   end
 end

--- a/lib/ask_export/targets/aws_s3.rb
+++ b/lib/ask_export/targets/aws_s3.rb
@@ -3,6 +3,11 @@ require "aws-sdk-s3"
 module AskExport
   module Targets
     class AwsS3
+      def self.bucket_name_from_env(name)
+        env_var_name = "S3_BUCKET_NAME_#{name.upcase.gsub(/-/, '_')}"
+        ENV[env_var_name]
+      end
+
       def initialize
         @client = Aws::S3::Client.new
       end
@@ -22,10 +27,7 @@ module AskExport
         puts "AWS S3 export: #{filename} uploaded to s3://#{bucket_name}"
       end
 
-      def self.bucket_name_from_env(name)
-        env_var_name = "S3_BUCKET_NAME_#{name.upcase.gsub(/-/, '_')}"
-        ENV[env_var_name]
-      end
+      def cleanup(name); end
     end
   end
 end

--- a/lib/ask_export/targets/filesystem.rb
+++ b/lib/ask_export/targets/filesystem.rb
@@ -15,6 +15,8 @@ module AskExport
           File.expand_path("../../../output", __dir__),
         )
       end
+
+      def cleanup; end
     end
   end
 end

--- a/lib/ask_export/targets/google_drive.rb
+++ b/lib/ask_export/targets/google_drive.rb
@@ -6,6 +6,11 @@ module AskExport
     class GoogleDrive
       SCOPE = Google::Apis::DriveV3::AUTH_DRIVE
 
+      def self.folder_id_from_env(name)
+        env_var_name = "FOLDER_ID_#{name.upcase.gsub(/-/, '_')}"
+        ENV[env_var_name]
+      end
+
       def initialize
         @drive_service = Google::Apis::DriveV3::DriveService.new
         @drive_service.authorization = Google::Auth::ServiceAccountCredentials.make_creds(scope: SCOPE)
@@ -24,9 +29,27 @@ module AskExport
         puts "Google Drive export: #{filename} uploaded to https://drive.google.com/drive/folders/#{folder_id}"
       end
 
-      def self.folder_id_from_env(name)
-        env_var_name = "FOLDER_ID_#{name.upcase.gsub(/-/, '_')}"
-        ENV[env_var_name]
+      def cleanup(pipeline_name)
+        folder_id = GoogleDrive.folder_id_from_env(pipeline_name)
+
+        files = @drive_service.list_files(
+          q: "'#{folder_id}' in parents",
+          include_items_from_all_drives: true,
+          supports_all_drives: true,
+          fields: "files(id,name,createdTime)",
+          page_size: 1000,
+        ).files
+
+        puts "Google Drive: Found #{files.count} existing files"
+        files.each do |file|
+          next if file.created_time > 3.months.ago
+
+          puts "Google Drive: Deleting file #{file.name}"
+          @drive_service.delete_file(
+            file.id,
+            supports_all_drives: true,
+          )
+        end
       end
     end
   end

--- a/lib/ask_export/targets/targets.rb
+++ b/lib/ask_export/targets/targets.rb
@@ -18,5 +18,9 @@ module AskExport
         target
       end
     end
+
+    def self.clear_cache
+      @target_cache = {}
+    end
   end
 end

--- a/spec/ask_export/pipeline_spec.rb
+++ b/spec/ask_export/pipeline_spec.rb
@@ -69,4 +69,28 @@ RSpec.describe AskExport::Pipeline do
       expect(target_b).to have_received(:export).with("pipeline-a", "file-a.csv", "completed-data")
     end
   end
+
+  describe "#cleanup" do
+    let(:target_a) { spy("TargetA") }
+    let(:target_b) { spy("TargetB") }
+
+    before do
+      allow(AskExport::Targets).to receive(:find).with("target_a").and_return(target_a)
+      allow(AskExport::Targets).to receive(:find).with("target_b").and_return(target_b)
+    end
+
+    it "calls the correct export target" do
+      pipeline = AskExport::Pipeline.new(
+        name: "pipeline-a",
+        fields: %i[a b],
+        only_completed: true,
+        targets: %w[target_a target_b],
+      )
+
+      pipeline.cleanup
+
+      expect(target_a).to have_received(:cleanup).with("pipeline-a")
+      expect(target_b).to have_received(:cleanup).with("pipeline-a")
+    end
+  end
 end

--- a/spec/ask_export/targets/google_drive_spec.rb
+++ b/spec/ask_export/targets/google_drive_spec.rb
@@ -13,6 +13,31 @@ RSpec.describe AskExport::Targets::GoogleDrive do
     end
   end
 
+  describe "#cleanup" do
+    it "list files and delete files that are 3 months or older" do
+      stub_drive_authentication
+      files = [
+        { id: 1, name: "file-1", createdTime: 4.months.ago.iso8601.to_s },
+        { id: 2, name: "file-2", createdTime: 3.months.ago.iso8601.to_s },
+        { id: 3, name: "file-3", createdTime: 1.months.ago.iso8601.to_s },
+      ]
+      stub_google_drive_list_files("folder-id", files)
+
+      stubs = [1, 2].map do |id|
+        stub_google_drive_delete_file(id)
+      end
+
+      target = AskExport::Targets::GoogleDrive.new
+      ClimateControl.modify FOLDER_ID_PIPELINE_NAME: "folder-id" do
+        target.cleanup("pipeline-name")
+      end
+
+      stubs.each do |stub|
+        expect(stub).to have_been_requested
+      end
+    end
+  end
+
   describe "#folder_id_from_env" do
     it "returns an folder id" do
       ClimateControl.modify FOLDER_ID_SOME_NAME: "folder-id" do

--- a/spec/integration/run_cleanup_spec.rb
+++ b/spec/integration/run_cleanup_spec.rb
@@ -1,0 +1,37 @@
+RSpec.describe "Clean up export targets" do
+  around do |example|
+    freeze_time { example.run }
+  end
+
+  it "fetches surveys and creates files for them" do
+    stub_aws_s3_client
+    stub_drive_authentication
+
+    co_files = [
+      { id: 1, name: "file-1", createdTime: 3.months.ago.iso8601.to_s },
+      { id: 2, name: "file-2", createdTime: 1.months.ago.iso8601.to_s },
+    ]
+
+    tp_files = [
+      { id: 3, name: "file-1", createdTime: 3.months.ago.iso8601.to_s },
+      { id: 4, name: "file-2", createdTime: 1.months.ago.iso8601.to_s },
+    ]
+    stub_google_drive_list_files("cabinet-office", co_files)
+    stub_google_drive_list_files("third-party", tp_files)
+
+    stubs = [1, 3].map do |id|
+      stub_google_drive_delete_file(id)
+    end
+
+    ClimateControl.modify(FOLDER_ID_CABINET_OFFICE: "cabinet-office",
+                          FOLDER_ID_THIRD_PARTY: "third-party",
+                          SMART_SURVEY_API_TOKEN: "token",
+                          SMART_SURVEY_API_TOKEN_SECRET: "token") do
+      Rake::Task["run_cleanup"].invoke
+    end
+
+    stubs.each do |stub|
+      expect(stub).to have_been_requested
+    end
+  end
+end

--- a/spec/integration/run_exports_spec.rb
+++ b/spec/integration/run_exports_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe "File export" do
     dlp_client = stub_dlp_client
     expect_deidentify_to_called(dlp_client, [match(/Answer/)] * 50, ["A question?"] * 50)
 
+    AskExport::Targets.clear_cache
     s3_client = stub_aws_s3_client
     stub_drive_authentication
 

--- a/spec/support/helpers/google_drive_helper.rb
+++ b/spec/support/helpers/google_drive_helper.rb
@@ -20,4 +20,42 @@ module GoogleDriveHelper
       },
     )
   end
+
+  def stub_google_drive_list_files(folder_id, files)
+    files_response = files.map do |file|
+      { "kind": "drive#file" }.merge(file)
+    end
+
+    stub_request(:get, %r{googleapis\.com/drive/v3/files})
+    .with(
+      query: hash_including({
+        "fields" => "files(id,name,createdTime)",
+        "pageSize" => "1000",
+        "includeItemsFromAllDrives" => "true",
+        "supportsAllDrives" => "true",
+        "q" => "'#{folder_id}' in parents",
+      }),
+    ).and_return(
+      body: {
+        "kind": "drive#fileList",
+        "files": files_response,
+      }.to_json,
+      headers: {
+        content_type: "application/json",
+      },
+    )
+  end
+
+  def stub_google_drive_delete_file(id)
+    stub_request(:delete, %r{googleapis\.com/drive/v3/files/#{id}})
+    .with(
+      query: hash_including({
+        "supportsAllDrives" => "true",
+      }),
+    ).and_return(
+      headers: {
+        content_type: "application/json",
+      },
+    )
+  end
 end


### PR DESCRIPTION
This adds a cleanup method for targets to delete any files that are 3 months or older. This is determined based on the createdAt time, which should be accurate as the data within the file should corresponds to the day that file was created.