### PR TITLE
Add cleanup rake task to Concourse

### DIFF
--- a/concourse.yml
+++ b/concourse.yml
@@ -71,6 +71,7 @@ jobs:
                 set -e
                 bundle install --deployment
                 bundle exec rake run_exports
+                bundle exec rake run_cleanup
                 bundle exec rake delete_data
           params:
             SINCE_TIME: 00:00


### PR DESCRIPTION
This adds the cleanup task to delete old files in Google Drive to the Concourse pipeline, so that it is run every day. It runs after the export process, so that failures don't interrupt the exports being generated.