### PR TITLE
Support exporting an "event" SmartSurvey variable

### DIFF
--- a/lib/ask_export/response.rb
+++ b/lib/ask_export/response.rb
@@ -2,12 +2,13 @@ require "smart_survey/response"
 
 module AskExport
   class Response < ::SmartSurvey::Response
-    attr_accessor :region, :question, :share_video, :name, :email, :phone
+    attr_accessor :event, :region, :question, :share_video, :name, :email, :phone
     alias_method :end_time, :ended
     alias_method :start_time, :started
 
     def initialize(**kwargs)
       super(kwargs)
+      @event = variables["event"]
       @region = fetch_answer(:region_field_id)
       @question = fetch_answer(:question_field_id)
       @share_video = fetch_answer(:share_video_field_id)

--- a/lib/smart_survey/response.rb
+++ b/lib/smart_survey/response.rb
@@ -7,23 +7,29 @@ module SmartSurvey
         hash[question[:id]] = answer.fetch(:value, answer[:choice_title])
       end
 
+      variables = response.fetch(:variables, []).each_with_object({}) do |variable, memo|
+        memo[variable[:name]] = variable[:value]
+      end
+
       new(
         id: response[:id],
         status: response[:status],
         started: Time.zone.iso8601(response[:date_started]),
         ended: Time.zone.iso8601(response[:date_ended]),
         answers: answers,
+        variables: variables,
       )
     end
 
-    attr_reader :id, :status, :started, :ended, :answers
+    attr_reader :id, :status, :started, :ended, :answers, :variables
 
-    def initialize(id:, status:, started:, ended:, answers:)
+    def initialize(id:, status:, started:, ended:, answers:, variables:)
       @id = id
       @status = status
       @started = started
       @ended = ended
       @answers = answers
+      @variables = variables
     end
 
     def completed?

--- a/spec/ask_export/response_spec.rb
+++ b/spec/ask_export/response_spec.rb
@@ -16,7 +16,12 @@ RSpec.describe AskExport::Response do
   describe "#new" do
     it "returns the initialize object with correct attributes" do
       response = described_class.new(
-        id: 1, status: "completed", started: started, ended: ended, answers: answers,
+        id: 1,
+        status: "completed",
+        started: started,
+        ended: ended,
+        answers: answers,
+        variables: { "event" => "disco" },
       )
 
       expect(response).to have_attributes(
@@ -32,32 +37,38 @@ RSpec.describe AskExport::Response do
         name: "Alex Doe",
         email: "test@example.com",
         phone: "123456789",
+        event: "disco",
       )
     end
   end
 
   describe "#status" do
+    let(:params) do
+      {
+        id: 1,
+        started: nil,
+        ended: nil,
+        answers: {},
+        variables: {},
+      }
+    end
+
     it "return submitted status if not completed" do
+      response = described_class.new(params.merge(status: "partial"))
+
+      expect(response.status).to eq("partial")
+    end
+
+    it "returns 'partial' when status is completed but some answers are missing" do
       response = described_class.new(
-        id: 1, status: "partial", started: nil, ended: nil, answers: {},
+        params.merge(status: "completed", answers: answers.merge(12_861_884 => nil)),
       )
 
       expect(response.status).to eq("partial")
     end
 
-    it "return 'partial' if completed but field missing" do
-      response = described_class.new(
-        id: 1, status: "completed", started: nil, ended: nil,
-        answers: answers.merge({ 12_861_884 => nil })
-      )
-
-      expect(response.status).to eq("partial")
-    end
-
-    it "return 'partial' if completed but field missing" do
-      response = described_class.new(
-        id: 1, status: "completed", started: nil, ended: nil, answers: answers,
-      )
+    it "returns 'completed' when status is completed and answers are present" do
+      response = described_class.new(params.merge(status: "completed", answers: answers))
 
       expect(response.status).to eq("completed")
     end

--- a/spec/factories/ask_export.rb
+++ b/spec/factories/ask_export.rb
@@ -25,6 +25,7 @@ FactoryBot.define do
           12_861_886 => email,
           12_861_885 => phone,
         },
+        variables: {},
       )
     end
   end

--- a/spec/factories/smart_survey.rb
+++ b/spec/factories/smart_survey.rb
@@ -63,11 +63,19 @@ FactoryBot.define do
     questions { [association(:question)] }
   end
 
+  factory :variable, class: OpenStruct do
+    sequence(:id, 1_000_000)
+    sequence(:name) { |n| "name-#{n}" }
+    sequence(:value) { |n| "value-#{n}" }
+    label { "" }
+  end
+
   factory :response, class: OpenStruct do
     sequence(:id, 100_000_000)
     date_started { "2020-02-09T18:38:05Z" }
     date_ended { "2020-02-09T18:42:04Z" }
     status { "completed" }
     pages { [association(:page)] }
+    variables { [association(:variable)] }
   end
 end

--- a/spec/smart_survey/response_spec.rb
+++ b/spec/smart_survey/response_spec.rb
@@ -90,21 +90,50 @@ RSpec.describe SmartSurvey::Response do
         )
       end
     end
+
+    context "when variables are in the payload" do
+      it "returns the object with a hash of variables" do
+        variable1 = hash(:variable, name: "event", value: "party")
+        variable2 = hash(:variable, name: "_gaId", value: "analytics")
+        raw_response = hash(:response, variables: [variable1, variable2])
+
+        response = described_class.parse(raw_response)
+        expect(response).to have_attributes(
+          variables: hash_including("event" => "party", "_gaId" => "analytics"),
+        )
+      end
+    end
+
+    context "when variables aren't provided in the payload" do
+      it "returns the object with empty variables" do
+        raw_response = hash(:response, variables: [])
+
+        response = described_class.parse(raw_response)
+        expect(response).to have_attributes(variables: {})
+      end
+    end
   end
 
   describe "#completed?" do
+    let(:params) do
+      {
+        id: nil,
+        status: "completed",
+        started: nil,
+        ended: nil,
+        answers: [],
+        variables: {},
+      }
+    end
+
     it "returns true if status is completed" do
-      response = described_class.new(
-        id: nil, status: "completed", started: nil, ended: nil, answers: [],
-      )
+      response = described_class.new(params.merge(status: "completed"))
 
       expect(response.completed?).to be(true)
     end
 
     it "returns true if status is partial" do
-      response = described_class.new(
-        id: nil, status: "partial", started: nil, ended: nil, answers: [],
-      )
+      response = described_class.new(params.merge(status: "partial"))
 
       expect(response.completed?).to be(false)
     end


### PR DESCRIPTION
Trello: https://trello.com/c/XA7exEnS/683-one-off-asks-jazz-up-the-data-exports-and-wrap-it-all-up-in-a-bow
Trello: https://trello.com/c/G1Fp1oEc/188-ask-one-offs-create-a-proof-of-concept

We intend to allow this survey to be associated with different events
(such asking a particular minister a question). The approach to
distinguishing between submissions for these events (and non event
submissions) is intended to be via the use of a Smart Survey Custom
Variable [1].

This change provides support for a variable with a name of "event".
Later, we will adapt the export pipelines to include references to this
variable so it can be included in exports.

[1]: https://help.smartsurvey.co.uk/article/custom-variables