### PR TITLE
Change slack channel for notifications

### DIFF
--- a/concourse.yml
+++ b/concourse.yml
@@ -1,6 +1,6 @@
 ---
 slack_settings: &slack_settings
-  channel: '#coronavirus-services-developer-only'
+  channel: '#govuk-corona-services-tech'
   username: GOV.UK Ask Export
   icon_emoji: ':concourse:'
   silent: true


### PR DESCRIPTION
The developer-only channel is a place for the devs to mob on problems,
it's really an appropriate place for notifications.

The more crowded "tech" channel is where other notifications are received.