### PR TITLE
Include the event variable in Cabinet Office and third party exports

### DIFF
--- a/config/pipelines.yml
+++ b/config/pipelines.yml
@@ -11,6 +11,7 @@ pipelines:
       - email
       - phone
       - share_video
+      - event
   third-party:
     targets:
       - google_drive
@@ -20,6 +21,7 @@ pipelines:
       - region
       - question
       - share_video
+      - event
   gcs-public-questions:
     targets:
       - aws_s3


### PR DESCRIPTION
Trello: https://trello.com/c/XA7exEnS/272-one-off-asks-jazz-up-the-data-exports-and-wrap-it-all-up-in-a-bow

This adds an additional field to the CSV outputs for Cabinet Office and
third party exports of event. The event variable is an example of a
Smart Survey custom variable that is set by a query string (handling of
this was introduced in 9872334). This custom variable has been created
in the draft and live surveys.

The parties receiving this spreadsheet requested this be added as the
last column in their CSV to avoid this breaking any existing scripts
that process the sheets.