### PR TITLE
Include event field in S3 exports

### DIFF
--- a/config/pipelines.yml
+++ b/config/pipelines.yml
@@ -30,3 +30,4 @@ pipelines:
       - end_time
       - region
       - question
+      - event


### PR DESCRIPTION
This has been requested to be included in the file used by the data
standards team at the Cabinet Office.