### PR TITLE
Update to basic auth before 1 November 2022

### DIFF
--- a/lib/smart_survey/client.rb
+++ b/lib/smart_survey/client.rb
@@ -17,6 +17,7 @@ module SmartSurvey
           retry_statuses: [401, 409, 408, 429, 500, 501, 502, 503, 504],
         }
 
+        f.request(:basic_auth, credentials[:api_token], credentials[:api_token_secret])
         f.request(:retry, retry_options)
         f.response(:raise_error)
       end


### PR DESCRIPTION
We have been informed by `SmartSurvey` that query string authentication will no longer be supported on 1 November 2022.

Basic auth is required beyond that date.

```text
Dear SmartSurvey API User,

This is a reminder that you need to take action to update your SmartSurvey API integrations. 
You are being sent this email because there is at least one API key registered to your SmartSurvey 
account which has used query string authentication in the last 30 days.

If your integrations are not updated to use Basic Auth, they will stop working on the 1st of November, 2022.
```

This change updates the service to basic auth.

Documentation: 

- [Faraday v.1.x usage](https://github.com/lostisland/faraday/blob/main/docs/middleware/request/authentication.md#faraday-1x-usage)

Co-authored-by: Alex Newton <alex.newton@digital.cabinet-office.gov.uk>

[Trello](https://trello.com/c/H2sPYXlk/211-update-smartsurvey-api-before-1st-november-for-ask-the-government-a-question)