### PR TITLE
Update configuration

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,7 +150,7 @@ DEPENDENCIES
   webmock
 
 RUBY VERSION
-   ruby 2.7.6p219
+   ruby 2.6.6
 
 BUNDLED WITH
    2.1.4

--- a/config/pipelines.yml
+++ b/config/pipelines.yml
@@ -22,9 +22,3 @@ pipelines:
       - question
       - share_video
       - event
-    only_completed: true
-    fields:
-      - end_time
-      - region
-      - question
-      - event


### PR DESCRIPTION
[It was noticed](https://github.com/alphagov/govuk-ask-export/pull/62#issuecomment-1268705381) that the app was struggling with the Bundler version that the app was bundled with and that some configuration was not fully removed as part of https://github.com/alphagov/govuk-ask-export/commit/79cd744406a9303533f7014ff2fca11760907f1f.

This change ensures Ruby 2.6.6 is used consistently across the app by re-bundling the `Gemfile.lock` - this should fix any issues that Bundler is currently having, and removes the duplicate third-party pipeline entries. Please note that `end_time` - which appears in the second set of config entries, but not in the first set - has been kept.

[Trello](https://trello.com/c/SOvnuRh1/224-no-longer-export-ask-service-data-to-s3)