### PR TITLE
Fix dupicate auth issue

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,7 +150,7 @@ DEPENDENCIES
   webmock
 
 RUBY VERSION
-   ruby 2.6.6
+   ruby 2.6.6p146
 
 BUNDLED WITH
-   2.1.4
+   1.17.2

--- a/lib/smart_survey/client.rb
+++ b/lib/smart_survey/client.rb
@@ -7,8 +7,7 @@ module SmartSurvey
     PAGE_SIZE = 100
 
     def initialize
-      credentials = { api_token: api_token, api_token_secret: api_token_secret }
-      @conn = Faraday.new(BASE_URL, params: credentials) do |f|
+      @conn = Faraday.new(BASE_URL) do |f|
         retry_options = {
           max: 3,
           interval: 1,
@@ -17,7 +16,7 @@ module SmartSurvey
           retry_statuses: [401, 409, 408, 429, 500, 501, 502, 503, 504],
         }
 
-        f.request(:basic_auth, credentials[:api_token], credentials[:api_token_secret])
+        f.request(:basic_auth, api_token, api_token_secret)
         f.request(:retry, retry_options)
         f.response(:raise_error)
       end

--- a/spec/integration/delete_data_spec.rb
+++ b/spec/integration/delete_data_spec.rb
@@ -11,17 +11,17 @@ RSpec.describe "Delete data" do
     )
 
     old_responses_requests = stub_get_responses(
-      survey_id, old_responses.dup, { until_time: 3.months.ago }
+      survey_id, old_responses.dup, "dG9rZW46dG9rZW4=", { until_time: 3.months.ago }
     )
 
     partial_responses = ask_smart_survey_responses(2, { status: "partial" })
 
     partial_responses_requests = stub_get_responses(
-      survey_id, partial_responses.dup, { completed: "0" }
+      survey_id, partial_responses.dup, "dG9rZW46dG9rZW4=", { completed: "0" }
     )
 
     delete_requests = (old_responses + partial_responses).map do |response|
-      stub_delete_response(survey_id, response[:id])
+      stub_delete_response(survey_id, response[:id], "dG9rZW46dG9rZW4=")
     end
 
     ClimateControl.modify(SMART_SURVEY_API_TOKEN: "token",

--- a/spec/integration/run_exports_spec.rb
+++ b/spec/integration/run_exports_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "File export" do
   let!(:smart_survey_request) do
     survey_id = AskExport.config(:survey_id)
     responses = ask_smart_survey_responses(50)
-    stub_get_responses(survey_id, responses).first
+    stub_get_responses(survey_id, responses, "dG9rZW46dG9rZW4=").first
   end
 
   it "fetches surveys and creates files for them" do

--- a/spec/smart_survey/client_spec.rb
+++ b/spec/smart_survey/client_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe SmartSurvey::Client do
     it "make the requests with correct parameters" do
       responses = smart_survey_responses(200)
       requests = stub_get_responses(
-        survey_id, responses, since_time: since_time, until_time: until_time
+        survey_id, responses, "Og==", { since_time: since_time, until_time: until_time }
       )
 
       client.list_responses(
@@ -29,7 +29,7 @@ RSpec.describe SmartSurvey::Client do
     end
 
     it "returns an array of responses" do
-      stub_get_responses(survey_id, smart_survey_responses(2))
+      stub_get_responses(survey_id, smart_survey_responses(2), "Og==")
       responses = client.list_responses(survey_id: survey_id)
 
       expect(responses).to contain_exactly(
@@ -39,14 +39,14 @@ RSpec.describe SmartSurvey::Client do
     end
 
     it "can retreive more responses than maximum page size of 100" do
-      stub_get_responses(survey_id, smart_survey_responses(250))
+      stub_get_responses(survey_id, smart_survey_responses(250), "Og==")
       responses = client.list_responses(survey_id: survey_id)
 
       expect(responses.count).to eq(250)
     end
 
     it "sleeps between each request" do
-      stub_get_responses(survey_id, smart_survey_responses(250))
+      stub_get_responses(survey_id, smart_survey_responses(250), "Og==")
 
       expect_any_instance_of(described_class).to receive(:sleep).twice
       client.list_responses(survey_id: survey_id)
@@ -56,7 +56,7 @@ RSpec.describe SmartSurvey::Client do
   describe "#delete_response" do
     it "makes request with correct parameters" do
       response_id = "987654321"
-      request = stub_delete_response(survey_id, response_id)
+      request = stub_delete_response(survey_id, response_id, "Og==")
 
       client.delete_response(survey_id: survey_id, response_id: response_id)
 


### PR DESCRIPTION
This change fixes two issues:

- The errors caused by the use of a version of `bundler` that is not available when deployed. We are simply reverting to the previous Ruby and Bundler versions.

- The introduction of both query string and basic auth from: https://github.com/alphagov/govuk-ask-export/pull/64 - we only need and want basic auth, so query string auth should be removed.

[Trello](https://trello.com/c/H2sPYXlk/211-update-smartsurvey-api-before-1st-november-for-ask-the-government-a-question)